### PR TITLE
v0.3: selector extensions + multi-pseudo + native text spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## 0.3.0
+
+### Features
+
+- **Selector engine extensions** (`GmlSelector`):
+  - Sibling combinators: `.a + .b` (adjacent), `.a ~ .b` (general)
+  - Substring attribute matchers: `[class~="bar"]`, `[href^="https://"]`,
+    `[src$=".png"]`, `[href*="example"]`
+  - Structural pseudo-classes: `:first-child`, `:last-child`, `:only-child`,
+    `:nth-child(n|odd|even|an+b)`, `:not(selector)`
+  - Specificity unchanged — structural pseudos count as class-level per spec
+- **Multi-pseudo combined states**: a selector like `button:hover:focus`
+  now resolves into a sorted combined bucket (`_focus+hover`) and the
+  renderer applies it only when ALL listed states are simultaneously active.
+  Single-pseudo rules continue to emit the legacy `_hover` / `_focus` /
+  `_active` / `_disabled` flat keys so existing consumers keep working.
+- **Button transitions honor combined buckets**: `GmlButtonBuilder` now
+  delegates to the shared `GmlTransitionSetup.setup_with_signals` engine,
+  so `button:hover:focus`, `button:hover:active`, etc. transition
+  correctly instead of being silently ignored.
+- **letter-spacing and word-spacing render natively** via `FontVariation`
+  (`spacing_glyph` and `spacing_space`). No more `label.text` mutation
+  and no more "metadata only" placeholder.
+
+### Behavior changes
+
+- Rules whose pseudo list contains any unknown state name (e.g. `:hovr`,
+  or a typo within `:hover:hovr`) are dropped with a warning instead of
+  being silently routed into a known bucket.
+- `GmlTransitionSetup` is rewritten around generic state-bucket discovery.
+  Same-size buckets now merge in lexicographic key order, making the
+  simultaneous-states case deterministic across runs.
+
+### Limitations / deferred
+
+- `text-indent` has no native Label support in Godot 4 and remains
+  metadata-only. A future release may route paragraphs through
+  `RichTextLabel` for `[indent]` BBCode support.
+- `_active` / `_disabled` state buckets resolve correctly for non-button
+  elements but the renderer does not yet emit input signals for them on
+  inputs/anchors — only buttons drive `active` (via button_down/up).
+
+
 ## 0.2.0
 
 ### Breaking changes

--- a/addons/gtml/plugin.cfg
+++ b/addons/gtml/plugin.cfg
@@ -3,5 +3,5 @@
 name="GTML - Godot Text Markup Language"
 description="GmlView node that builds Godot UI from HTML/CSS files"
 author="Digitzone"
-version="0.2.0"
+version="0.3.0"
 script="plugin.gd"

--- a/addons/gtml/src/css/GmlSelector.gd
+++ b/addons/gtml/src/css/GmlSelector.gd
@@ -500,12 +500,17 @@ static func _prev_element_sibling(parent, current):
 
 
 ## True when the 1-based ``position`` satisfies ``an + b`` for some non-negative
-## integer n. ``a == 0`` reduces to ``position == b``.
+## integer n. ``a == 0`` reduces to ``position == b``. Uses integer arithmetic
+## so very large positions don't lose precision.
 static func _nth_matches(position: int, a: int, b: int) -> bool:
 	if a == 0:
 		return position == b
-	var n: float = float(position - b) / float(a)
-	return n >= 0 and n == floor(n)
+	var diff: int = position - b
+	# n must be a non-negative integer satisfying a*n == diff
+	if a > 0:
+		return diff >= 0 and (diff % a) == 0
+	# a < 0 — solutions exist when diff <= 0 and diff % a == 0
+	return diff <= 0 and (diff % a) == 0
 
 
 static func _attr_matches(attr: Dictionary, node) -> bool:

--- a/addons/gtml/src/css/GmlSelector.gd
+++ b/addons/gtml/src/css/GmlSelector.gd
@@ -20,6 +20,13 @@ extends RefCounted
 ## sort declarations.
 
 
+## State pseudos affect runtime appearance (the renderer toggles them via
+## input events) but do NOT participate in DOM matching. Anything else with a
+## ":" prefix is treated as a structural pseudo and routed through the
+## matcher's structural-pseudo path.
+const STATE_PSEUDOS := ["hover", "active", "focus", "disabled"]
+
+
 class Compound:
 	## A single compound selector (one element's constraints).
 	var tag: String = ""        # empty = universal/no tag constraint
@@ -27,6 +34,12 @@ class Compound:
 	var classes: PackedStringArray = PackedStringArray()
 	var attrs: Array = []       # Array of {name, op, value}
 	var pseudos: PackedStringArray = PackedStringArray()
+	## Structural pseudos affect DOM matching. Each entry:
+	##   {type: String, arg: Variant}
+	## type ∈ {"first-child", "last-child", "only-child", "nth-child", "not"}.
+	## - nth-child arg is a Dictionary {a: int, b: int} encoding an+b.
+	## - not arg is a parsed Selector.
+	var structural_pseudos: Array = []
 
 
 class Selector:
@@ -45,6 +58,7 @@ class Selector:
 			cls += c.classes.size()
 			cls += c.attrs.size()
 			cls += c.pseudos.size()
+			cls += c.structural_pseudos.size()
 			if not c.tag.is_empty():
 				tags += 1
 		return Vector3i(ids, cls, tags)
@@ -61,21 +75,18 @@ static func parse(s: String) -> Selector:
 	while i < n:
 		var ch := s[i]
 
-		# Whitespace -> descendant combinator (unless adjacent to >)
+		# Whitespace -> descendant combinator (unless followed by an explicit combinator).
 		if ch == " " or ch == "\t" or ch == "\n":
 			i += 1
-			# look ahead for explicit combinator
 			while i < n and (s[i] == " " or s[i] == "\t" or s[i] == "\n"):
 				i += 1
 			if i >= n:
 				break
-			if s[i] == ">":
-				# child combinator
+			if s[i] == ">" or s[i] == "+" or s[i] == "~":
 				_finalize_compound(sel, current, pending_combinator)
 				current = Compound.new()
-				pending_combinator = ">"
+				pending_combinator = s[i]
 				i += 1
-				# skip trailing whitespace
 				while i < n and (s[i] == " " or s[i] == "\t" or s[i] == "\n"):
 					i += 1
 				continue
@@ -85,11 +96,14 @@ static func parse(s: String) -> Selector:
 			pending_combinator = " "
 			continue
 
-		if ch == ">":
+		if ch == ">" or ch == "+" or ch == "~":
 			_finalize_compound(sel, current, pending_combinator)
 			current = Compound.new()
-			pending_combinator = ">"
+			pending_combinator = ch
 			i += 1
+			# eat trailing whitespace after the combinator
+			while i < n and (s[i] == " " or s[i] == "\t" or s[i] == "\n"):
+				i += 1
 			continue
 
 		if ch == "#":
@@ -109,8 +123,21 @@ static func parse(s: String) -> Selector:
 		if ch == ":":
 			i += 1
 			var p_end := _read_ident_end(s, i)
-			current.pseudos.append(s.substr(i, p_end - i))
+			var pseudo_name: String = s.substr(i, p_end - i)
 			i = p_end
+			# Optional argument: :name(arg) — parse balanced parens, honoring
+			# nested () and quoted "/' regions inside.
+			var arg: String = ""
+			var has_arg := false
+			if i < n and s[i] == "(":
+				has_arg = true
+				var arg_end := _find_paren_close(s, i + 1)
+				if arg_end < 0:
+					push_warning("GmlSelector: unterminated pseudo argument in '%s'" % s)
+					break
+				arg = s.substr(i + 1, arg_end - i - 1).strip_edges()
+				i = arg_end + 1
+			_route_pseudo(current, pseudo_name, arg, has_arg)
 			continue
 
 		if ch == "[":
@@ -158,13 +185,122 @@ static func _parse_attr(inner: String) -> Dictionary:
 	var eq := inner.find("=")
 	if eq < 0:
 		return {"name": inner.strip_edges(), "op": "", "value": ""}
-	var name := inner.substr(0, eq).strip_edges()
-	var value := inner.substr(eq + 1).strip_edges()
-	# Strip surrounding quotes
+
+	# The operator may be one of "=", "~=", "^=", "$=", "*=". The first three
+	# substring matchers borrow the character immediately before the "=".
+	var op: String = "="
+	var name_end: int = eq
+	if eq > 0:
+		var prev: String = inner[eq - 1]
+		if prev == "~" or prev == "^" or prev == "$" or prev == "*":
+			op = prev + "="
+			name_end = eq - 1
+
+	var name: String = inner.substr(0, name_end).strip_edges()
+	var value: String = inner.substr(eq + 1).strip_edges()
 	if value.length() >= 2 and ((value.begins_with("\"") and value.ends_with("\""))
 			or (value.begins_with("'") and value.ends_with("'"))):
 		value = value.substr(1, value.length() - 2)
-	return {"name": name, "op": "=", "value": value}
+	return {"name": name, "op": op, "value": value}
+
+
+## Find the matching `)` for a `(` at position ``from - 1``, respecting nested
+## parens and quoted regions. Returns -1 if no terminator is found.
+static func _find_paren_close(s: String, from: int) -> int:
+	var i := from
+	var n := s.length()
+	var depth := 1
+	var in_quote := ""
+	while i < n:
+		var ch := s[i]
+		if in_quote != "":
+			if ch == "\\" and i + 1 < n:
+				i += 2
+				continue
+			if ch == in_quote:
+				in_quote = ""
+			i += 1
+			continue
+		if ch == "\"" or ch == "'":
+			in_quote = ch
+		elif ch == "(":
+			depth += 1
+		elif ch == ")":
+			depth -= 1
+			if depth == 0:
+				return i
+		i += 1
+	return -1
+
+
+## Dispatch a parsed pseudo into the appropriate compound bucket.
+## Structural pseudos (first-child, nth-child, not, ...) go to structural_pseudos
+## so the matcher checks them at match time. State pseudos (hover, focus, ...)
+## go to pseudos so the resolver routes the rule into the right state bucket.
+static func _route_pseudo(c: Compound, name: String, arg: String, has_arg: bool) -> void:
+	match name:
+		"first-child", "last-child", "only-child":
+			c.structural_pseudos.append({"type": name, "arg": null})
+		"nth-child":
+			c.structural_pseudos.append({"type": "nth-child", "arg": _parse_nth(arg)})
+		"not":
+			# :not() takes a selector argument. We parse it as a full Selector
+			# but at match time only consider its rightmost compound — combinator
+			# arguments inside :not() are deferred past v0.3.
+			c.structural_pseudos.append({"type": "not", "arg": parse(arg)})
+		_:
+			if has_arg:
+				push_warning("GmlSelector: unsupported pseudo with argument ':%s(%s)' — rule will not match anything" % [name, arg])
+				# Push a never-matches sentinel so the rule is dropped at match time.
+				c.structural_pseudos.append({"type": "_never", "arg": null})
+			else:
+				c.pseudos.append(name)
+
+
+## Parse an nth-child argument into {a, b} encoding ``an + b``.
+## Accepts integer ("3"), keywords ("odd" -> 2n+1, "even" -> 2n), and the
+## an+b syntax ("2n+1", "3n-1", "-n+3"). Returns {a: 0, b: 0} on parse failure
+## (never-matches because there is no element at position 0).
+static func _parse_nth(raw: String) -> Dictionary:
+	var s := raw.strip_edges().to_lower()
+	if s == "odd":
+		return {"a": 2, "b": 1}
+	if s == "even":
+		return {"a": 2, "b": 0}
+	if s.is_valid_int():
+		return {"a": 0, "b": s.to_int()}
+
+	# an+b — locate the "n", split at it
+	var n_pos := s.find("n")
+	if n_pos < 0:
+		return {"a": 0, "b": 0}
+	var a_str := s.substr(0, n_pos).strip_edges()
+	var b_str := s.substr(n_pos + 1).strip_edges()
+	var a: int
+	if a_str.is_empty() or a_str == "+":
+		a = 1
+	elif a_str == "-":
+		a = -1
+	elif a_str.is_valid_int():
+		a = a_str.to_int()
+	else:
+		return {"a": 0, "b": 0}
+	var b: int = 0
+	if not b_str.is_empty():
+		# b_str includes its sign, e.g. "+1" or "-3"
+		if b_str.is_valid_int():
+			b = b_str.to_int()
+		else:
+			# strip leading sign if needed
+			var sign := 1
+			if b_str.begins_with("+"):
+				b_str = b_str.substr(1)
+			elif b_str.begins_with("-"):
+				sign = -1
+				b_str = b_str.substr(1)
+			if b_str.is_valid_int():
+				b = sign * b_str.to_int()
+	return {"a": a, "b": b}
 
 
 ## Find the closing ``]`` of an attribute selector starting at ``from``,
@@ -208,39 +344,72 @@ static func _read_ident_end(s: String, start: int) -> int:
 
 ## Test whether a Selector matches a DOM node given an explicit ancestor chain
 ## (root-first; the node itself is the last element of the chain).
+##
+## The walk goes right-to-left through compounds. Each combinator chooses how
+## to advance the "current candidate" — descendant/child step up the chain,
+## sibling combinators stay at the same depth and step through the parent's
+## children. ``parent_idx`` always points at the chain entry that is the
+## current candidate's parent, so structural pseudos and sibling lookups can
+## both ask "what are my siblings?" cheaply.
 static func matches(sel: Selector, ancestor_chain: Array) -> bool:
 	if sel.compounds.is_empty() or ancestor_chain.is_empty():
 		return false
 
-	# The rightmost compound must match the candidate node itself.
-	var node = ancestor_chain[ancestor_chain.size() - 1]
-	var ci := sel.compounds.size() - 1
-	if not _compound_matches(sel.compounds[ci], node):
+	var current_node = ancestor_chain[ancestor_chain.size() - 1]
+	var parent_idx: int = ancestor_chain.size() - 2
+
+	var ci: int = sel.compounds.size() - 1
+	if not _compound_matches(sel.compounds[ci], current_node, ancestor_chain, parent_idx):
 		return false
 
-	# Walk leftward through compounds, consuming the ancestor chain.
-	var ai := ancestor_chain.size() - 2
 	ci -= 1
 	while ci >= 0:
 		var combinator: String = sel.combinators[ci]
-		var target = sel.compounds[ci]
+		var target: Compound = sel.compounds[ci]
 		match combinator:
 			">":
-				if ai < 0:
+				if parent_idx < 0:
 					return false
-				if not _compound_matches(target, ancestor_chain[ai]):
+				current_node = ancestor_chain[parent_idx]
+				parent_idx -= 1
+				if not _compound_matches(target, current_node, ancestor_chain, parent_idx):
 					return false
-				ai -= 1
 			" ":
-				# Walk back until a match is found
 				var matched := false
-				while ai >= 0:
-					if _compound_matches(target, ancestor_chain[ai]):
+				while parent_idx >= 0:
+					current_node = ancestor_chain[parent_idx]
+					parent_idx -= 1
+					if _compound_matches(target, current_node, ancestor_chain, parent_idx):
 						matched = true
-						ai -= 1
 						break
-					ai -= 1
 				if not matched:
+					return false
+			"+":
+				if parent_idx < 0:
+					return false
+				var parent = ancestor_chain[parent_idx]
+				var prev = _prev_element_sibling(parent, current_node)
+				if prev == null:
+					return false
+				current_node = prev
+				if not _compound_matches(target, current_node, ancestor_chain, parent_idx):
+					return false
+			"~":
+				if parent_idx < 0:
+					return false
+				var parent2 = ancestor_chain[parent_idx]
+				var found := false
+				var probe = current_node
+				while true:
+					var prev2 = _prev_element_sibling(parent2, probe)
+					if prev2 == null:
+						break
+					if _compound_matches(target, prev2, ancestor_chain, parent_idx):
+						current_node = prev2
+						found = true
+						break
+					probe = prev2
+				if not found:
 					return false
 			_:
 				return false
@@ -248,7 +417,7 @@ static func matches(sel: Selector, ancestor_chain: Array) -> bool:
 	return true
 
 
-static func _compound_matches(compound: Compound, node) -> bool:
+static func _compound_matches(compound: Compound, node, chain: Array, parent_idx: int) -> bool:
 	if node == null or node.is_text_node:
 		return false
 	if not compound.tag.is_empty() and node.tag != compound.tag:
@@ -263,9 +432,80 @@ static func _compound_matches(compound: Compound, node) -> bool:
 	for attr in compound.attrs:
 		if not _attr_matches(attr, node):
 			return false
-	# Pseudo-class matching is NOT done here — that's the renderer's job (state-based).
-	# Pseudo-classes only contribute to specificity at resolve time.
+	# Structural pseudos affect matching. State pseudos do not — those only
+	# contribute to specificity and to the resolver's state bucketing.
+	for sp in compound.structural_pseudos:
+		if not _structural_matches(sp, node, chain, parent_idx):
+			return false
 	return true
+
+
+## Test a structural pseudo (:first-child, :nth-child(...), :not(...), ...)
+## against ``node``. ``chain[parent_idx]`` is the node's parent (or invalid
+## when parent_idx < 0, meaning node is the root — first-child et al. all
+## fail because there are no siblings to compare against).
+static func _structural_matches(sp: Dictionary, node, chain: Array, parent_idx: int) -> bool:
+	var t: String = sp.get("type", "")
+	if t == "_never":
+		return false
+	if t == "not":
+		# Run the inner selector against an augmented chain ending at this node.
+		var inner = sp.get("arg")
+		if inner == null:
+			return false
+		var sub_chain: Array = chain.slice(0, parent_idx + 1)
+		sub_chain.append(node)
+		return not matches(inner, sub_chain)
+
+	# Remaining structural pseudos all need a parent for sibling indexing.
+	if parent_idx < 0:
+		return false
+	var parent = chain[parent_idx]
+	var element_siblings: Array = _element_children(parent)
+	var idx: int = element_siblings.find(node)
+	if idx < 0:
+		return false  # defensive: node is detached from its claimed parent
+
+	match t:
+		"first-child":
+			return idx == 0
+		"last-child":
+			return idx == element_siblings.size() - 1
+		"only-child":
+			return element_siblings.size() == 1
+		"nth-child":
+			var nth: Dictionary = sp.get("arg", {"a": 0, "b": 0})
+			return _nth_matches(idx + 1, nth.get("a", 0), nth.get("b", 0))
+		_:
+			return false
+
+
+## Return the element children of ``node`` (text nodes filtered out).
+static func _element_children(node) -> Array:
+	var out: Array = []
+	for c in node.children:
+		if c != null and not c.is_text_node:
+			out.append(c)
+	return out
+
+
+## The element sibling immediately before ``current`` in ``parent``'s element
+## children, or null if ``current`` is the first / not found.
+static func _prev_element_sibling(parent, current):
+	var children := _element_children(parent)
+	var idx := children.find(current)
+	if idx <= 0:
+		return null
+	return children[idx - 1]
+
+
+## True when the 1-based ``position`` satisfies ``an + b`` for some non-negative
+## integer n. ``a == 0`` reduces to ``position == b``.
+static func _nth_matches(position: int, a: int, b: int) -> bool:
+	if a == 0:
+		return position == b
+	var n: float = float(position - b) / float(a)
+	return n >= 0 and n == floor(n)
 
 
 static func _attr_matches(attr: Dictionary, node) -> bool:
@@ -280,6 +520,17 @@ static func _attr_matches(attr: Dictionary, node) -> bool:
 	match op:
 		"=":
 			return got == want
+		"~=":
+			# Whitespace-separated word list contains `want` as a whole word.
+			if want.is_empty():
+				return false
+			return want in got.split(" ", false)
+		"^=":
+			return not want.is_empty() and got.begins_with(want)
+		"$=":
+			return not want.is_empty() and got.ends_with(want)
+		"*=":
+			return not want.is_empty() and got.contains(want)
 		_:
 			return false
 

--- a/addons/gtml/src/css/GmlStyleResolver.gd
+++ b/addons/gtml/src/css/GmlStyleResolver.gd
@@ -37,22 +37,25 @@ func _resolve_node(node, ancestor_chain: Array, rules: Array, styles: Dictionary
 
 ## Walks all rules, gathers the matching ones for ``node``, sorts them by
 ## (specificity, source_index), and merges them into one final style dict.
+##
+## Single-pseudo rules land in legacy flat keys (``_hover``, ``_focus``,
+## ``_active``, ``_disabled``) so the existing transition path keeps working
+## unchanged. Multi-pseudo rules (e.g. ``a:hover:focus``) land in a combined
+## bucket keyed by ``_`` + sorted pseudos joined with ``+`` (so
+## ``a:hover:focus`` and ``a:focus:hover`` produce the same ``_focus+hover``
+## key). A rule whose pseudo set contains any unknown state pseudo is dropped
+## with a warning — see test_multi_pseudo.
 func _compute_style(node, ancestor_chain: Array, rules: Array) -> Dictionary:
-	var matches: Array = []  # Array of {rule, specificity, pseudo}
+	var matches: Array = []
 
 	for rule in rules:
 		if rule.selector == null:
 			continue
 		if not GmlSelector.matches(rule.selector, ancestor_chain):
 			continue
-		# Use the rightmost compound's pseudo to decide the style bucket.
-		# Multi-pseudo (a:hover:focus) is deferred to v0.3 — we currently route
-		# such rules to the first pseudo's bucket.
-		var pseudo := _primary_pseudo(rule.selector)
 		matches.append({
 			"rule": rule,
 			"specificity": rule.specificity(),
-			"pseudo": pseudo,
 			"source_index": rule.source_index,
 		})
 
@@ -62,49 +65,49 @@ func _compute_style(node, ancestor_chain: Array, rules: Array) -> Dictionary:
 	matches.sort_custom(_compare_matches)
 
 	var style: Dictionary = {}
-	var hover_style: Dictionary = {}
-	var active_style: Dictionary = {}
-	var focus_style: Dictionary = {}
-	var disabled_style: Dictionary = {}
+	var state_buckets: Dictionary = {}  # bucket_key -> Dict
 
 	for m in matches:
 		var props: Dictionary = m["rule"].properties
-		match m["pseudo"]:
-			"":
-				_merge_properties(style, props)
-			"hover":
-				_merge_properties(hover_style, props)
-			"active":
-				_merge_properties(active_style, props)
-			"focus":
-				_merge_properties(focus_style, props)
-			"disabled":
-				_merge_properties(disabled_style, props)
-			_:
-				# Drop unknown pseudo rules — merging them into the base style
-				# would let a typo like :hovr silently overwrite the un-hovered
-				# appearance. Warn the developer so the typo is visible.
-				push_warning("GmlStyleResolver: unknown pseudo-class ':%s' — rule dropped" % m["pseudo"])
+		var sps := _state_pseudos_of(m["rule"].selector)
 
-	if not hover_style.is_empty():
-		style["_hover"] = hover_style
-	if not active_style.is_empty():
-		style["_active"] = active_style
-	if not focus_style.is_empty():
-		style["_focus"] = focus_style
-	if not disabled_style.is_empty():
-		style["_disabled"] = disabled_style
+		if sps.is_empty():
+			_merge_properties(style, props)
+			continue
+
+		# Reject rules whose pseudo list contains any unknown name. Routing
+		# such a rule into a known bucket would silently change the visual
+		# behavior; dropping it surfaces the typo via push_warning.
+		var unknown_pseudo: String = ""
+		for p in sps:
+			if not (p in GmlSelector.STATE_PSEUDOS):
+				unknown_pseudo = p
+				break
+		if not unknown_pseudo.is_empty():
+			push_warning("GmlStyleResolver: unknown pseudo-class ':%s' — rule dropped" % unknown_pseudo)
+			continue
+
+		var sorted_pseudos := sps.duplicate()
+		sorted_pseudos.sort()
+		var bucket_key: String = "+".join(sorted_pseudos)
+		if not state_buckets.has(bucket_key):
+			state_buckets[bucket_key] = {}
+		_merge_properties(state_buckets[bucket_key], props)
+
+	for key in state_buckets:
+		style["_" + key] = state_buckets[key]
 
 	return style
 
 
-static func _primary_pseudo(sel) -> String:
+## All state pseudos on the selector's rightmost compound, in source order.
+## Anything not in STATE_PSEUDOS is returned as-is so the caller can detect
+## unknowns and drop the rule.
+static func _state_pseudos_of(sel) -> PackedStringArray:
 	if sel == null or sel.compounds.is_empty():
-		return ""
+		return PackedStringArray()
 	var last = sel.compounds[sel.compounds.size() - 1]
-	if last.pseudos.is_empty():
-		return ""
-	return last.pseudos[0]
+	return last.pseudos.duplicate()
 
 
 ## Order rules so the highest-priority is last (so the final merge wins).

--- a/addons/gtml/src/html_renderer/GmlStyles.gd
+++ b/addons/gtml/src/html_renderer/GmlStyles.gd
@@ -38,10 +38,11 @@ static func apply_text_styles(label: Label, style: Dictionary, defaults: Diction
 	if not family.is_empty() or style.has("font-weight"):
 		_apply_font_family_and_weight(label, family, weight, defaults)
 
-	# Letter spacing: applied via a FontVariation wrapping the resolved font.
-	# Stored as metadata for consumers that read it back, and visually
-	# realized via spacing_glyph on the variation.
-	if style.has("letter-spacing"):
+	# Letter spacing AND word spacing both flow through a single FontVariation
+	# applied to the resolved font. Calling _apply_font_spacing once handles
+	# either or both keys; the helper reuses an existing FontVariation override
+	# if one is already on the label.
+	if style.has("letter-spacing") or style.has("word-spacing"):
 		_apply_font_spacing(label, style)
 
 	# Text transform (uppercase, lowercase, capitalize)
@@ -60,19 +61,6 @@ static func apply_text_styles(label: Label, style: Dictionary, defaults: Diction
 	if style.has("line-height"):
 		var line_height: int = style["line-height"]
 		label.add_theme_constant_override("line_spacing", line_height)
-
-	# Word spacing: applied via the same FontVariation as letter-spacing.
-	# (Skipped above if letter-spacing already handled it.)
-	if style.has("word-spacing") and not style.has("letter-spacing"):
-		_apply_font_spacing(label, style)
-	elif style.has("word-spacing"):
-		# Already created the variation for letter-spacing; just stamp the
-		# word-spacing onto it. _apply_font_spacing is idempotent so we can
-		# call again, but skip the redundant work.
-		var fv = label.get_theme_font("font")
-		if fv is FontVariation:
-			(fv as FontVariation).spacing_space = style["word-spacing"]
-		label.set_meta("word_spacing", style["word-spacing"])
 
 	# text-indent: no native Label support in Godot 4. Stored as metadata so
 	# consumers (or future RichTextLabel-backed elements) can read it back.

--- a/addons/gtml/src/html_renderer/GmlStyles.gd
+++ b/addons/gtml/src/html_renderer/GmlStyles.gd
@@ -38,11 +38,11 @@ static func apply_text_styles(label: Label, style: Dictionary, defaults: Diction
 	if not family.is_empty() or style.has("font-weight"):
 		_apply_font_family_and_weight(label, family, weight, defaults)
 
-	# Letter spacing: NO text mutation. Stored as metadata for renderers /
-	# consumers that want to read it back. Visual application is deferred to
-	# v0.3 \u2014 proper character spacing requires a RichTextLabel migration.
+	# Letter spacing: applied via a FontVariation wrapping the resolved font.
+	# Stored as metadata for consumers that read it back, and visually
+	# realized via spacing_glyph on the variation.
 	if style.has("letter-spacing"):
-		label.set_meta("letter_spacing", style["letter-spacing"])
+		_apply_font_spacing(label, style)
 
 	# Text transform (uppercase, lowercase, capitalize)
 	if style.has("text-transform"):
@@ -61,11 +61,21 @@ static func apply_text_styles(label: Label, style: Dictionary, defaults: Diction
 		var line_height: int = style["line-height"]
 		label.add_theme_constant_override("line_spacing", line_height)
 
-	# Word spacing and text-indent: stored as metadata only (see letter-spacing).
-	# Both used to splice Unicode spaces into label.text, which silently
-	# corrupted .text round-trips. Visual application is deferred to v0.3.
-	if style.has("word-spacing"):
+	# Word spacing: applied via the same FontVariation as letter-spacing.
+	# (Skipped above if letter-spacing already handled it.)
+	if style.has("word-spacing") and not style.has("letter-spacing"):
+		_apply_font_spacing(label, style)
+	elif style.has("word-spacing"):
+		# Already created the variation for letter-spacing; just stamp the
+		# word-spacing onto it. _apply_font_spacing is idempotent so we can
+		# call again, but skip the redundant work.
+		var fv = label.get_theme_font("font")
+		if fv is FontVariation:
+			(fv as FontVariation).spacing_space = style["word-spacing"]
 		label.set_meta("word_spacing", style["word-spacing"])
+
+	# text-indent: no native Label support in Godot 4. Stored as metadata so
+	# consumers (or future RichTextLabel-backed elements) can read it back.
 	if style.has("text-indent"):
 		label.set_meta("text_indent", style["text-indent"])
 
@@ -87,6 +97,37 @@ static func apply_text_transform(label: Label, transform: String) -> void:
 			pass  # Keep original text
 
 	label.set_meta("text_transform", transform)
+
+
+## Wrap the label's current font in a FontVariation and apply CSS
+## letter-spacing / word-spacing via spacing_glyph / spacing_space.
+##
+## If the label already has a FontVariation override we reuse it so a single
+## label that has both letter-spacing and word-spacing ends up with one
+## FontVariation, not two stacked.
+##
+## When the resolved base font is a SystemFont we cannot wrap it directly
+## (FontVariation needs a FontFile/FontVariation in base_font); in that case
+## we set the variation's base_font to the SystemFont and rely on Godot's
+## fallback chain — spacing still applies because spacing_* is on the
+## variation itself, independent of the wrapped font.
+static func _apply_font_spacing(label: Label, style: Dictionary) -> void:
+	var fv: FontVariation
+	var existing = label.get_theme_font("font") if label.has_theme_font_override("font") else null
+	if existing is FontVariation:
+		fv = existing
+	else:
+		fv = FontVariation.new()
+		if existing is Font:
+			fv.base_font = existing
+		label.add_theme_font_override("font", fv)
+
+	if style.has("letter-spacing"):
+		fv.spacing_glyph = int(style["letter-spacing"])
+		label.set_meta("letter_spacing", style["letter-spacing"])
+	if style.has("word-spacing"):
+		fv.spacing_space = int(style["word-spacing"])
+		label.set_meta("word_spacing", style["word-spacing"])
 
 
 ## Resolve font-family + font-weight against the user-supplied fonts dict.

--- a/addons/gtml/src/html_renderer/GmlTransitionSetup.gd
+++ b/addons/gtml/src/html_renderer/GmlTransitionSetup.gd
@@ -17,8 +17,9 @@ extends RefCounted
 ## them simply never fire.
 
 
-## State pseudos the runtime currently tracks. Anything else in a bucket key
-## means the bucket can never become active.
+## Default state pseudos the renderer is willing to track on a generic Control.
+## Buttons override this via setup_with_signals() so their active/pressed
+## state participates in bucket matching too.
 const TRACKED_STATES := ["hover", "focus"]
 
 
@@ -26,36 +27,43 @@ const TRACKED_STATES := ["hover", "focus"]
 ## so the transition manager interpolates the style as states toggle.
 ## No-op if there are no transitions defined or no state buckets present.
 static func setup(control: Control, style: Dictionary, transition_manager) -> void:
+	var signals: Array = [
+		{"state": "hover", "on_enter": control.mouse_entered, "on_exit": control.mouse_exited},
+		{"state": "focus", "on_enter": control.focus_entered, "on_exit": control.focus_exited},
+	]
+	setup_with_signals(control, style, transition_manager, signals)
+
+
+## Generic state-bucket transition setup. ``signals`` is a list of
+## ``{state: String, on_enter: Signal, on_exit: Signal}`` entries that tell us
+## which pseudo states to track and which Signal pair toggles each. Buttons
+## use this directly to add ``active`` (button_down/up) on top of the hover +
+## focus pair the generic ``setup()`` provides.
+static func setup_with_signals(control: Control, style: Dictionary, transition_manager, signals: Array) -> void:
 	var transitions: Array = style.get("transition", [])
 	if transitions.is_empty() or transition_manager == null:
 		return
 
-	# Extract all state buckets (keys prefixed with "_"). Each bucket is
-	# (sorted-pseudo-set, props). We skip "_disabled"/"_active" buckets at the
-	# event level (no runtime signal), but we still parse them so future wiring
-	# can pick them up.
 	var buckets: Array = _collect_state_buckets(style)
 	if buckets.is_empty():
 		return
 
-	# Determine which tracked events are actually needed. If no bucket
-	# references hover, don't bother connecting mouse signals; same for focus.
-	var needs_hover := false
-	var needs_focus := false
+	# Only connect handlers for states some bucket actually references.
+	var needed: Dictionary = {}
 	for b in buckets:
-		if "hover" in (b["set"] as Array):
-			needs_hover = true
-		if "focus" in (b["set"] as Array):
-			needs_focus = true
-	if not (needs_hover or needs_focus):
+		for p in (b["set"] as Array):
+			needed[p] = true
+	var any_signal_needed := false
+	for spec in signals:
+		if needed.get(spec["state"], false):
+			any_signal_needed = true
+			break
+	if not any_signal_needed:
 		return
 
 	var base_style: Dictionary = _strip_state_keys(style)
 	_normalize_border_properties(base_style)
 
-	# Cache stylebox metas so the transition manager can interpolate corner
-	# radius, border width, and border color even when they come from the
-	# border shorthand.
 	var stylebox_props: Dictionary = {}
 	if base_style.has("border-radius"):
 		stylebox_props["corner_radius"] = base_style["border-radius"]
@@ -65,34 +73,29 @@ static func setup(control: Control, style: Dictionary, transition_manager) -> vo
 		stylebox_props["border_color"] = base_style["border-color"]
 	control.set_meta("_stylebox_props", stylebox_props)
 
-	var state := {"hover": false, "focus": false}
+	var state: Dictionary = {}
+	for spec in signals:
+		state[spec["state"]] = false
 
 	var apply_transition := func(prev_state: Dictionary):
 		var from_style: Dictionary = _compute_target(base_style, buckets, prev_state)
 		var to_style: Dictionary = _compute_target(base_style, buckets, state)
 		transition_manager.transition_style(control, from_style, to_style, transitions)
 
-	if needs_hover:
-		control.mouse_entered.connect(func():
+	for spec in signals:
+		var state_name: String = spec["state"]
+		if not needed.get(state_name, false):
+			continue
+		var enter_sig: Signal = spec["on_enter"]
+		var exit_sig: Signal = spec["on_exit"]
+		enter_sig.connect(func():
 			var prev := state.duplicate()
-			state["hover"] = true
+			state[state_name] = true
 			apply_transition.call(prev)
 		)
-		control.mouse_exited.connect(func():
+		exit_sig.connect(func():
 			var prev := state.duplicate()
-			state["hover"] = false
-			apply_transition.call(prev)
-		)
-
-	if needs_focus:
-		control.focus_entered.connect(func():
-			var prev := state.duplicate()
-			state["focus"] = true
-			apply_transition.call(prev)
-		)
-		control.focus_exited.connect(func():
-			var prev := state.duplicate()
-			state["focus"] = false
+			state[state_name] = false
 			apply_transition.call(prev)
 		)
 
@@ -113,8 +116,26 @@ static func _collect_state_buckets(style: Dictionary) -> Array:
 		if body == "stylebox_props":
 			continue
 		var set: Array = Array(body.split("+", false))
-		out.append({"set": set, "props": style[key], "size": set.size()})
-	out.sort_custom(func(a, b): return int(a["size"]) < int(b["size"]))
+		# Sort the set itself so two buckets that mention the same pseudos
+		# in different source orders share a stable comparison key. The
+		# resolver already emits sorted-key bucket names so this is normally
+		# a no-op, but defensive sorting keeps the tie-break deterministic.
+		set.sort()
+		out.append({
+			"set": set,
+			"props": style[key],
+			"size": set.size(),
+			"key": "+".join(set),
+		})
+	# Sort by ascending set size so larger (more specific) buckets are
+	# merged last in _compute_target. For same-size buckets, fall back to
+	# the lexicographic key so the merge order is stable across runs —
+	# Godot's sort_custom is not guaranteed stable.
+	out.sort_custom(func(a, b):
+		if int(a["size"]) != int(b["size"]):
+			return int(a["size"]) < int(b["size"])
+		return str(a["key"]) < str(b["key"])
+	)
 	return out
 
 

--- a/addons/gtml/src/html_renderer/GmlTransitionSetup.gd
+++ b/addons/gtml/src/html_renderer/GmlTransitionSetup.gd
@@ -2,41 +2,60 @@ class_name GmlTransitionSetup
 extends RefCounted
 
 ## Wires hover/focus signal handlers on a control so the GmlTransitionManager
-## can interpolate between base and pseudo-class style dictionaries.
+## can interpolate between style states.
 ##
-## Mouse and focus state are tracked together so that, e.g., releasing hover
-## while focus is still held returns the control to the focus style rather
-## than the base style.
+## v0.3 supports multi-pseudo combined states. The resolver emits one bucket
+## per distinct sorted pseudo set: ``_hover``, ``_focus``, ``_focus+hover``,
+## etc. At each event we recompute the active set, look up every bucket whose
+## set is a subset of it, and merge them in (size, source-order) order to
+## produce the target style. The "more specific" bucket (e.g.
+## ``_focus+hover`` over ``_hover``) wins because it's merged later.
+##
+## Active / disabled state pseudos parse and resolve correctly but the
+## renderer does not yet emit events for them — that wiring is deferred to
+## a later release. They're treated as always-false here so rules that mention
+## them simply never fire.
+
+
+## State pseudos the runtime currently tracks. Anything else in a bucket key
+## means the bucket can never become active.
+const TRACKED_STATES := ["hover", "focus"]
 
 
 ## Connect mouse_entered/exited and focus_entered/exited handlers on ``control``
-## using transition definitions and pseudo-class overrides from ``style``.
-## No-op if there are no transitions or no pseudo-classes to interpolate to.
+## so the transition manager interpolates the style as states toggle.
+## No-op if there are no transitions defined or no state buckets present.
 static func setup(control: Control, style: Dictionary, transition_manager) -> void:
 	var transitions: Array = style.get("transition", [])
 	if transitions.is_empty() or transition_manager == null:
 		return
 
-	var hover_style: Dictionary = style.get("_hover", {})
-	var focus_style: Dictionary = style.get("_focus", {})
-	if hover_style.is_empty() and focus_style.is_empty():
+	# Extract all state buckets (keys prefixed with "_"). Each bucket is
+	# (sorted-pseudo-set, props). We skip "_disabled"/"_active" buckets at the
+	# event level (no runtime signal), but we still parse them so future wiring
+	# can pick them up.
+	var buckets: Array = _collect_state_buckets(style)
+	if buckets.is_empty():
 		return
 
-	# Build a clean base style with pseudo keys stripped + border shorthand exploded.
-	var base_style: Dictionary = style.duplicate()
-	for k in ["_hover", "_active", "_focus", "_disabled"]:
-		base_style.erase(k)
+	# Determine which tracked events are actually needed. If no bucket
+	# references hover, don't bother connecting mouse signals; same for focus.
+	var needs_hover := false
+	var needs_focus := false
+	for b in buckets:
+		if "hover" in (b["set"] as Array):
+			needs_hover = true
+		if "focus" in (b["set"] as Array):
+			needs_focus = true
+	if not (needs_hover or needs_focus):
+		return
+
+	var base_style: Dictionary = _strip_state_keys(style)
 	_normalize_border_properties(base_style)
 
-	var hover_complete := base_style.duplicate()
-	for key in hover_style:
-		hover_complete[key] = hover_style[key]
-
-	var focus_complete := base_style.duplicate()
-	for key in focus_style:
-		focus_complete[key] = focus_style[key]
-
-	# Cache stylebox props in meta so the transition manager can reach them.
+	# Cache stylebox metas so the transition manager can interpolate corner
+	# radius, border width, and border color even when they come from the
+	# border shorthand.
 	var stylebox_props: Dictionary = {}
 	if base_style.has("border-radius"):
 		stylebox_props["corner_radius"] = base_style["border-radius"]
@@ -46,32 +65,84 @@ static func setup(control: Control, style: Dictionary, transition_manager) -> vo
 		stylebox_props["border_color"] = base_style["border-color"]
 	control.set_meta("_stylebox_props", stylebox_props)
 
-	# Shared state across the four handlers below.
-	var state := {"is_hovered": false, "is_focused": false}
+	var state := {"hover": false, "focus": false}
 
-	if not hover_style.is_empty():
+	var apply_transition := func(prev_state: Dictionary):
+		var from_style: Dictionary = _compute_target(base_style, buckets, prev_state)
+		var to_style: Dictionary = _compute_target(base_style, buckets, state)
+		transition_manager.transition_style(control, from_style, to_style, transitions)
+
+	if needs_hover:
 		control.mouse_entered.connect(func():
-			state.is_hovered = true
-			var from_style: Dictionary = focus_complete if state.is_focused else base_style
-			transition_manager.transition_style(control, from_style, hover_complete, transitions)
+			var prev := state.duplicate()
+			state["hover"] = true
+			apply_transition.call(prev)
 		)
 		control.mouse_exited.connect(func():
-			state.is_hovered = false
-			var to_style: Dictionary = focus_complete if state.is_focused else base_style
-			transition_manager.transition_style(control, hover_complete, to_style, transitions)
+			var prev := state.duplicate()
+			state["hover"] = false
+			apply_transition.call(prev)
 		)
 
-	if not focus_style.is_empty():
+	if needs_focus:
 		control.focus_entered.connect(func():
-			state.is_focused = true
-			if not state.is_hovered:
-				transition_manager.transition_style(control, base_style, focus_complete, transitions)
+			var prev := state.duplicate()
+			state["focus"] = true
+			apply_transition.call(prev)
 		)
 		control.focus_exited.connect(func():
-			state.is_focused = false
-			if not state.is_hovered:
-				transition_manager.transition_style(control, focus_complete, base_style, transitions)
+			var prev := state.duplicate()
+			state["focus"] = false
+			apply_transition.call(prev)
 		)
+
+
+## Read every ``_*`` key on ``style`` and return them as a sorted list of
+## {set: Array[String], props: Dictionary, size: int}. Sorting by size ascending
+## ensures that when we apply matching buckets in order, the most specific
+## (largest matching set) wins by being merged last.
+static func _collect_state_buckets(style: Dictionary) -> Array:
+	var out: Array = []
+	for key in style.keys():
+		var k := str(key)
+		if not k.begins_with("_") or k.length() < 2:
+			continue
+		var body := k.substr(1)
+		# Skip non-state internal metadata (e.g. _stylebox_props would have
+		# been added by our own caching; defensive guard).
+		if body == "stylebox_props":
+			continue
+		var set: Array = Array(body.split("+", false))
+		out.append({"set": set, "props": style[key], "size": set.size()})
+	out.sort_custom(func(a, b): return int(a["size"]) < int(b["size"]))
+	return out
+
+
+## Strip every ``_*`` state-bucket key from ``style`` so what's left is the
+## base (no-state) style.
+static func _strip_state_keys(style: Dictionary) -> Dictionary:
+	var out: Dictionary = style.duplicate()
+	for key in style.keys():
+		if str(key).begins_with("_"):
+			out.erase(key)
+	return out
+
+
+## Merge ``base`` with every bucket whose pseudo set ⊆ the active state,
+## producing the style that should be shown for that state combination.
+static func _compute_target(base: Dictionary, buckets: Array, active: Dictionary) -> Dictionary:
+	var out: Dictionary = base.duplicate()
+	for b in buckets:
+		var set: Array = b["set"]
+		var ok := true
+		for p in set:
+			if not active.get(p, false):
+				ok = false
+				break
+		if ok:
+			for key in (b["props"] as Dictionary):
+				out[key] = b["props"][key]
+	return out
 
 
 ## Pull border-color and border-width out of the ``border`` shorthand so the

--- a/addons/gtml/src/html_renderer/elements/GmlButtonBuilder.gd
+++ b/addons/gtml/src/html_renderer/elements/GmlButtonBuilder.gd
@@ -131,8 +131,13 @@ static func _build_simple_button(node, ctx: Dictionary, style: Dictionary, defau
 	return {"control": wrapped, "inner": button}
 
 
-## Set up transitions for a button.
-## Returns true if transitions are being used, false otherwise.
+## Set up transitions for a button using the shared state-bucket engine in
+## GmlTransitionSetup. Returns true if transitions were wired, false if the
+## button should fall back to the static-style path.
+##
+## v0.3: button transitions now honor combined-state buckets like
+## ``button:hover:focus`` because GmlTransitionSetup.setup_with_signals picks
+## up every ``_*`` key on the resolved style — not just the legacy flat trio.
 static func _setup_button_transitions(button: Button, style: Dictionary, defaults: Dictionary, ctx: Dictionary, skip_padding: bool = false) -> bool:
 	var transitions: Array = style.get("transition", [])
 	if transitions.is_empty():
@@ -142,127 +147,55 @@ static func _setup_button_transitions(button: Button, style: Dictionary, default
 	if transition_manager == null:
 		return false
 
-	# Get pseudo-class styles
-	var hover_style: Dictionary = style.get("_hover", {})
-	var active_style: Dictionary = style.get("_active", {})
-	var focus_style: Dictionary = style.get("_focus", {})
-
-	# If no pseudo-class styles defined, don't use transitions
-	if hover_style.is_empty() and active_style.is_empty() and focus_style.is_empty():
+	# Bail out if no state buckets exist — no point wiring transitions that
+	# will never fire. We check the same keys GmlTransitionSetup would see.
+	var has_state_bucket := false
+	for key in style.keys():
+		if str(key).begins_with("_"):
+			has_state_bucket = true
+			break
+	if not has_state_bucket:
 		return false
 
-	# Create base StyleBox and apply it
+	# Build a base stylebox up front. Godot needs all four button states
+	# (normal/hover/pressed/focus) overridden so it doesn't paint its theme
+	# defaults between transition frames.
 	var base_stylebox := StyleBoxFlat.new()
-
 	if style.has("background-color"):
 		base_stylebox.bg_color = style["background-color"]
 	else:
 		base_stylebox.bg_color = Color(0.2, 0.2, 0.2, 1.0)
-
-	# Padding
 	if not skip_padding:
 		var base_padding: int = style.get("padding", 8)
 		base_stylebox.content_margin_top = style.get("padding-top", base_padding)
 		base_stylebox.content_margin_right = style.get("padding-right", base_padding)
 		base_stylebox.content_margin_bottom = style.get("padding-bottom", base_padding)
 		base_stylebox.content_margin_left = style.get("padding-left", base_padding)
-
 	GmlStyles.apply_border_to_stylebox(base_stylebox, style)
 
-	# Apply base style to all states initially (we'll animate changes)
 	button.add_theme_stylebox_override("normal", base_stylebox)
 	button.add_theme_stylebox_override("hover", base_stylebox.duplicate())
 	button.add_theme_stylebox_override("pressed", base_stylebox.duplicate())
 	button.add_theme_stylebox_override("focus", base_stylebox.duplicate())
 
-	# Text color
 	if style.has("color"):
 		button.add_theme_color_override("font_color", style["color"])
 		button.add_theme_color_override("font_hover_color", style["color"])
 		button.add_theme_color_override("font_pressed_color", style["color"])
 		button.add_theme_color_override("font_focus_color", style["color"])
 
-	# Build complete style dictionaries for transitions
-	var base_style_complete := style.duplicate()
-	base_style_complete.erase("_hover")
-	base_style_complete.erase("_active")
-	base_style_complete.erase("_focus")
-	base_style_complete.erase("_disabled")
+	# Hand off bucket-driven event wiring to the shared engine. Buttons track
+	# three states: hover (mouse_entered/exited), active (button_down/up),
+	# focus (focus_entered/exited). Combined buckets like _active+hover or
+	# _focus+hover layer correctly on top of the singles.
+	var signals: Array = [
+		{"state": "hover", "on_enter": button.mouse_entered, "on_exit": button.mouse_exited},
+		{"state": "active", "on_enter": button.button_down, "on_exit": button.button_up},
+		{"state": "focus", "on_enter": button.focus_entered, "on_exit": button.focus_exited},
+	]
+	GmlTransitionSetup.setup_with_signals(button, style, transition_manager, signals)
 
-	# Normalize border properties - extract border-color from border shorthand
-	_normalize_border_properties(base_style_complete)
-
-	# Store stylebox properties for transition manager (after normalization)
-	var stylebox_props := {}
-	if base_style_complete.has("border-radius"):
-		stylebox_props["corner_radius"] = base_style_complete["border-radius"]
-	if base_style_complete.has("border-width"):
-		stylebox_props["border_width"] = base_style_complete["border-width"]
-	if base_style_complete.has("border-color"):
-		stylebox_props["border_color"] = base_style_complete["border-color"]
-	button.set_meta("_stylebox_props", stylebox_props)
-
-	# Merge base with pseudo-class for complete target styles
-	var hover_complete := base_style_complete.duplicate()
-	for key in hover_style:
-		hover_complete[key] = hover_style[key]
-
-	var active_complete := base_style_complete.duplicate()
-	for key in active_style:
-		active_complete[key] = active_style[key]
-
-	var focus_complete := base_style_complete.duplicate()
-	for key in focus_style:
-		focus_complete[key] = focus_style[key]
-
-	# Track button state
-	var state := {"current": "base", "is_pressed": false, "is_focused": false}
-
-	# Hover transitions
-	button.mouse_entered.connect(func():
-		if not state.is_pressed:
-			var from_style = base_style_complete
-			transition_manager.transition_style(button, from_style, hover_complete, transitions)
-			state.current = "hover"
-	)
-	button.mouse_exited.connect(func():
-		if not state.is_pressed:
-			var to_style = focus_complete if state.is_focused else base_style_complete
-			transition_manager.transition_style(button, hover_complete, to_style, transitions)
-			state.current = "focus" if state.is_focused else "base"
-	)
-
-	# Pressed/active transitions
-	button.button_down.connect(func():
-		state.is_pressed = true
-		var from_style = hover_complete if button.is_hovered() else base_style_complete
-		transition_manager.transition_style(button, from_style, active_complete, transitions)
-		state.current = "active"
-	)
-	button.button_up.connect(func():
-		state.is_pressed = false
-		var to_style = hover_complete if button.is_hovered() else base_style_complete
-		transition_manager.transition_style(button, active_complete, to_style, transitions)
-		state.current = "hover" if button.is_hovered() else "base"
-	)
-
-	# Focus transitions
-	button.focus_entered.connect(func():
-		state.is_focused = true
-		if not state.is_pressed and not button.is_hovered() and not focus_style.is_empty():
-			transition_manager.transition_style(button, base_style_complete, focus_complete, transitions)
-			state.current = "focus"
-	)
-	button.focus_exited.connect(func():
-		state.is_focused = false
-		if not state.is_pressed and not button.is_hovered() and not focus_style.is_empty():
-			transition_manager.transition_style(button, focus_complete, base_style_complete, transitions)
-			state.current = "base"
-	)
-
-	# Apply remaining non-transition styles
 	_apply_button_text_styles(button, style, defaults)
-
 	return true
 
 

--- a/tests/unit/test_multi_pseudo.gd
+++ b/tests/unit/test_multi_pseudo.gd
@@ -1,0 +1,111 @@
+extends GutTest
+
+## v0.3: multi-pseudo combined states.
+##
+## A selector like ``a:hover:focus`` should resolve into a bucket that the
+## renderer applies only when ALL of {hover, focus} are simultaneously active.
+## Single-pseudo styles still work and stack — the more-specific combined
+## state wins when its full pseudo set is active.
+
+const GmlHtmlParserScript = preload("res://addons/gtml/src/html_parser/GmlHtmlParser.gd")
+const GmlCssParserScript = preload("res://addons/gtml/src/css/GmlCssParser.gd")
+const GmlStyleResolverScript = preload("res://addons/gtml/src/css/GmlStyleResolver.gd")
+
+
+func _resolved_style(html: String, css: String, id: String) -> Dictionary:
+	var dom = GmlHtmlParserScript.new().parse(html)
+	var rules := GmlCssParserScript.new().parse(css)
+	var styles: Dictionary = GmlStyleResolverScript.new().resolve(dom, rules)
+	var node = _find_by_id(dom, id)
+	if node == null:
+		return {}
+	return styles.get(node, {})
+
+
+func _find_by_id(node, id: String):
+	if node == null or node.is_text_node:
+		return null
+	if node.get_id() == id:
+		return node
+	for c in node.children:
+		var r = _find_by_id(c, id)
+		if r != null:
+			return r
+	return null
+
+
+func test_single_pseudo_still_emits_legacy_flat_key() -> void:
+	# Backward compat: existing transition code reads style["_hover"].
+	var s := _resolved_style(
+		"<button id='target'>x</button>",
+		"button:hover { color: red; }",
+		"target")
+	assert_true(s.has("_hover"), "single :hover must still emit the _hover bucket")
+	assert_eq(s["_hover"].get("color"), Color.RED)
+
+
+func test_multi_pseudo_emits_combined_bucket() -> void:
+	var s := _resolved_style(
+		"<button id='target'>x</button>",
+		"button:hover:focus { color: red; }",
+		"target")
+	# Sorted state-pseudo bucket key is "focus+hover" (alphabetical).
+	assert_true(s.has("_focus+hover"),
+		"multi :hover:focus must emit a combined-state bucket, got keys: %s" % str(s.keys()))
+	assert_eq(s["_focus+hover"].get("color"), Color.RED)
+
+
+func test_multi_pseudo_bucket_key_is_sorted_regardless_of_source_order() -> void:
+	# focus:hover and hover:focus should land in the same bucket.
+	var s := _resolved_style(
+		"<button id='target'>x</button>",
+		"button:focus:hover { color: red; }",
+		"target")
+	assert_true(s.has("_focus+hover"))
+
+
+func test_single_and_multi_coexist() -> void:
+	var s := _resolved_style(
+		"<button id='target'>x</button>",
+		"button:hover { color: blue; } button:hover:focus { color: red; }",
+		"target")
+	assert_eq(s.get("_hover", {}).get("color"), Color.BLUE)
+	assert_eq(s.get("_focus+hover", {}).get("color"), Color.RED)
+
+
+func test_combined_bucket_wins_when_all_pseudos_active() -> void:
+	# Direct test of TransitionSetup's target-style computation: when both
+	# hover and focus are active, the focus+hover bucket must layer over the
+	# single _hover bucket (and over base).
+	var style := {
+		"color": Color.GREEN,
+		"_hover": {"color": Color.BLUE},
+		"_focus+hover": {"color": Color.RED},
+	}
+	var base := GtmlTransitionSetupTestProxy.strip_state_keys(style)
+	var buckets := GtmlTransitionSetupTestProxy.collect_state_buckets(style)
+
+	var only_hover: Dictionary = GtmlTransitionSetupTestProxy.compute_target(base, buckets, {"hover": true, "focus": false})
+	assert_eq(only_hover.get("color"), Color.BLUE, "hover-only should apply _hover bucket")
+
+	var both: Dictionary = GtmlTransitionSetupTestProxy.compute_target(base, buckets, {"hover": true, "focus": true})
+	assert_eq(both.get("color"), Color.RED, "hover+focus should apply combined bucket")
+
+	var none: Dictionary = GtmlTransitionSetupTestProxy.compute_target(base, buckets, {"hover": false, "focus": false})
+	assert_eq(none.get("color"), Color.GREEN, "no states should leave base color")
+
+
+func test_unknown_pseudo_in_multi_drops_rule() -> void:
+	# :hover:hovr — one valid + one typo. The whole rule should be dropped
+	# rather than silently routed into the _hover bucket (which would
+	# overwrite the un-typo'd :hover style).
+	var s := _resolved_style(
+		"<button id='target'>x</button>",
+		"button:hover { color: blue; } button:hover:hovr { color: red; }",
+		"target")
+	# _hover bucket must NOT have been polluted by the typo'd rule
+	assert_eq(s.get("_hover", {}).get("color"), Color.BLUE)
+	# And no combined bucket should have been emitted for the bad rule
+	for k in s.keys():
+		if str(k).begins_with("_") and "hovr" in str(k):
+			fail_test("typo pseudo leaked into bucket %s" % k)

--- a/tests/unit/test_multi_pseudo.gd
+++ b/tests/unit/test_multi_pseudo.gd
@@ -95,6 +95,21 @@ func test_combined_bucket_wins_when_all_pseudos_active() -> void:
 	assert_eq(none.get("color"), Color.GREEN, "no states should leave base color")
 
 
+func test_active_and_disabled_buckets_resolve_but_never_fire_on_non_buttons() -> void:
+	# Document the intentional limitation: the generic GmlTransitionSetup only
+	# tracks hover + focus signals on plain controls. _active / _disabled
+	# buckets parse and land on the style, but the runtime won't toggle them
+	# unless the element type drives those signals (buttons do; inputs/anchors
+	# don't yet). This test pins the resolver behavior so a future contributor
+	# can see the buckets exist and only the wiring is missing.
+	var s := _resolved_style(
+		"<a id='target' href='#'>x</a>",
+		"a:active { color: red; } a:disabled { color: gray; }",
+		"target")
+	assert_true(s.has("_active"), "active bucket must still resolve so future wiring picks it up")
+	assert_true(s.has("_disabled"), "disabled bucket must still resolve so future wiring picks it up")
+
+
 func test_unknown_pseudo_in_multi_drops_rule() -> void:
 	# :hover:hovr — one valid + one typo. The whole rule should be dropped
 	# rather than silently routed into the _hover bucket (which would

--- a/tests/unit/test_multi_pseudo.gd.uid
+++ b/tests/unit/test_multi_pseudo.gd.uid
@@ -1,0 +1,1 @@
+uid://ccsic3hbkdsmx

--- a/tests/unit/test_review_fixups.gd.uid
+++ b/tests/unit/test_review_fixups.gd.uid
@@ -1,0 +1,1 @@
+uid://ckpsiacsbtipf

--- a/tests/unit/test_selector_extensions.gd
+++ b/tests/unit/test_selector_extensions.gd
@@ -221,4 +221,49 @@ func test_not_does_not_match_when_excluded_class_present() -> void:
 	assert_false(s.has("color"))
 
 
+func test_nested_not_double_negative_matches() -> void:
+	# :not(:not(.x)) is the double-negative — should match elements WITH .x.
+	# Guards against accidental infinite recursion in the matcher.
+	var s = _style_for_id(
+		"<div><p id='target' class='x'></p></div>",
+		"p:not(:not(.x)) { color: red; }",
+		"target")
+	assert_eq(s.get("color"), Color.RED)
+
+
+func test_adjacent_sibling_parses_without_spaces() -> void:
+	# .a+.b (no whitespace around the combinator) must parse identically to
+	# ".a + .b". This pins the lexer branch that fires when a combinator
+	# character appears immediately after the previous compound.
+	var s = _style_for_id(
+		"<div><p class='a'></p><p id='target' class='b'></p></div>",
+		".a+.b { color: red; }",
+		"target")
+	assert_eq(s.get("color"), Color.RED)
+
+
+func test_nth_child_an_plus_b() -> void:
+	# nth-child(2n+1) -> 1st, 3rd, 5th. Third <li> (target) should match.
+	var s = _style_for_id(
+		"<ul><li>a</li><li>b</li><li id='target'>c</li></ul>",
+		"li:nth-child(2n+1) { color: red; }",
+		"target")
+	assert_eq(s.get("color"), Color.RED)
+
+
+func test_nth_child_negative_an_plus_b() -> void:
+	# nth-child(-n+2) -> first 2 elements. Second <li> (target) matches; third doesn't.
+	var s_in = _style_for_id(
+		"<ul><li>a</li><li id='target'>b</li><li>c</li></ul>",
+		"li:nth-child(-n+2) { color: red; }",
+		"target")
+	assert_eq(s_in.get("color"), Color.RED)
+
+	var s_out = _style_for_id(
+		"<ul><li>a</li><li>b</li><li id='target'>c</li></ul>",
+		"li:nth-child(-n+2) { color: red; }",
+		"target")
+	assert_false(s_out.has("color"))
+
+
 #endregion

--- a/tests/unit/test_selector_extensions.gd
+++ b/tests/unit/test_selector_extensions.gd
@@ -1,0 +1,224 @@
+extends GutTest
+
+## v0.3 selector engine extensions:
+##   - Sibling combinators (+ adjacent, ~ general)
+##   - Substring attribute matchers (~=, ^=, $=, *=)
+##   - Structural pseudo-classes (:not, :nth-child, :first-child, :last-child,
+##     :only-child)
+
+const GmlHtmlParserScript = preload("res://addons/gtml/src/html_parser/GmlHtmlParser.gd")
+const GmlCssParserScript = preload("res://addons/gtml/src/css/GmlCssParser.gd")
+const GmlStyleResolverScript = preload("res://addons/gtml/src/css/GmlStyleResolver.gd")
+const GmlSelectorScript = preload("res://addons/gtml/src/css/GmlSelector.gd")
+
+
+func _dom(html: String):
+	return GmlHtmlParserScript.new().parse(html)
+
+
+func _rules(css: String) -> Array:
+	return GmlCssParserScript.new().parse(css)
+
+
+func _style_for_id(html: String, css: String, id: String) -> Dictionary:
+	var dom = _dom(html)
+	var rules := _rules(css)
+	var styles: Dictionary = GmlStyleResolverScript.new().resolve(dom, rules)
+	var found = _find_by_id(dom, id)
+	if found == null:
+		return {}
+	return styles.get(found, {})
+
+
+func _find_by_id(node, id: String):
+	if node == null or node.is_text_node:
+		return null
+	if node.get_id() == id:
+		return node
+	for c in node.children:
+		var r = _find_by_id(c, id)
+		if r != null:
+			return r
+	return null
+
+
+#region Sibling combinators
+
+
+func test_adjacent_sibling_matches_immediate_next() -> void:
+	var s = _style_for_id(
+		"<div><p class='a'></p><p id='target' class='b'></p></div>",
+		".a + .b { color: red; }",
+		"target")
+	assert_eq(s.get("color"), Color.RED)
+
+
+func test_adjacent_sibling_does_not_match_skipped() -> void:
+	# .b separated from .a by another sibling — must NOT match (+ is strict)
+	var s = _style_for_id(
+		"<div><p class='a'></p><p class='middle'></p><p id='target' class='b'></p></div>",
+		".a + .b { color: red; }",
+		"target")
+	assert_false(s.has("color"))
+
+
+func test_general_sibling_matches_any_following() -> void:
+	# .b is two positions after .a — must still match ~
+	var s = _style_for_id(
+		"<div><p class='a'></p><p class='middle'></p><p id='target' class='b'></p></div>",
+		".a ~ .b { color: red; }",
+		"target")
+	assert_eq(s.get("color"), Color.RED)
+
+
+func test_sibling_does_not_match_when_no_preceding() -> void:
+	var s = _style_for_id(
+		"<div><p id='target' class='b'></p></div>",
+		".a ~ .b { color: red; }",
+		"target")
+	assert_false(s.has("color"))
+
+
+#endregion
+
+
+#region Substring attribute matchers
+
+
+func test_attr_whitespace_word_includes() -> void:
+	var s = _style_for_id(
+		'<div id="target" class="foo bar baz"></div>',
+		'[class~="bar"] { color: red; }',
+		"target")
+	assert_eq(s.get("color"), Color.RED)
+
+
+func test_attr_whitespace_word_no_substring_match() -> void:
+	# ~= matches whole words only — "bar" must not match "barley"
+	var s = _style_for_id(
+		'<div id="target" class="barley"></div>',
+		'[class~="bar"] { color: red; }',
+		"target")
+	assert_false(s.has("color"))
+
+
+func test_attr_prefix_match() -> void:
+	var s = _style_for_id(
+		'<a id="target" href="https://example.com">x</a>',
+		'[href^="https://"] { color: red; }',
+		"target")
+	assert_eq(s.get("color"), Color.RED)
+
+
+func test_attr_suffix_match() -> void:
+	var s = _style_for_id(
+		'<img id="target" src="logo.png">',
+		'[src$=".png"] { color: red; }',
+		"target")
+	assert_eq(s.get("color"), Color.RED)
+
+
+func test_attr_substring_match() -> void:
+	var s = _style_for_id(
+		'<a id="target" href="https://api.example.com/v1/users">x</a>',
+		'[href*="example"] { color: red; }',
+		"target")
+	assert_eq(s.get("color"), Color.RED)
+
+
+func test_attr_substring_no_match() -> void:
+	var s = _style_for_id(
+		'<a id="target" href="https://other.com/">x</a>',
+		'[href*="example"] { color: red; }',
+		"target")
+	assert_false(s.has("color"))
+
+
+#endregion
+
+
+#region Structural pseudo-classes
+
+
+func test_first_child_matches() -> void:
+	var s = _style_for_id(
+		"<ul><li id='target'>a</li><li>b</li></ul>",
+		"li:first-child { color: red; }",
+		"target")
+	assert_eq(s.get("color"), Color.RED)
+
+
+func test_first_child_does_not_match_second() -> void:
+	var s = _style_for_id(
+		"<ul><li>a</li><li id='target'>b</li></ul>",
+		"li:first-child { color: red; }",
+		"target")
+	assert_false(s.has("color"))
+
+
+func test_last_child_matches() -> void:
+	var s = _style_for_id(
+		"<ul><li>a</li><li id='target'>b</li></ul>",
+		"li:last-child { color: red; }",
+		"target")
+	assert_eq(s.get("color"), Color.RED)
+
+
+func test_only_child_matches_when_alone() -> void:
+	var s = _style_for_id(
+		"<ul><li id='target'>solo</li></ul>",
+		"li:only-child { color: red; }",
+		"target")
+	assert_eq(s.get("color"), Color.RED)
+
+
+func test_only_child_does_not_match_with_siblings() -> void:
+	var s = _style_for_id(
+		"<ul><li id='target'>a</li><li>b</li></ul>",
+		"li:only-child { color: red; }",
+		"target")
+	assert_false(s.has("color"))
+
+
+func test_nth_child_integer() -> void:
+	var s = _style_for_id(
+		"<ul><li>a</li><li id='target'>b</li><li>c</li></ul>",
+		"li:nth-child(2) { color: red; }",
+		"target")
+	assert_eq(s.get("color"), Color.RED)
+
+
+func test_nth_child_odd() -> void:
+	var s = _style_for_id(
+		"<ul><li>a</li><li id='target'>b</li><li>c</li></ul>",
+		"li:nth-child(odd) { color: red; }",
+		"target")
+	# Position 2 is even — odd should NOT match
+	assert_false(s.has("color"))
+
+
+func test_nth_child_even() -> void:
+	var s = _style_for_id(
+		"<ul><li>a</li><li id='target'>b</li><li>c</li></ul>",
+		"li:nth-child(even) { color: red; }",
+		"target")
+	assert_eq(s.get("color"), Color.RED)
+
+
+func test_not_excludes_class() -> void:
+	var s = _style_for_id(
+		"<div><p id='target'></p><p class='special'></p></div>",
+		"p:not(.special) { color: red; }",
+		"target")
+	assert_eq(s.get("color"), Color.RED)
+
+
+func test_not_does_not_match_when_excluded_class_present() -> void:
+	var s = _style_for_id(
+		"<div><p></p><p id='target' class='special'></p></div>",
+		"p:not(.special) { color: red; }",
+		"target")
+	assert_false(s.has("color"))
+
+
+#endregion

--- a/tests/unit/test_selector_extensions.gd.uid
+++ b/tests/unit/test_selector_extensions.gd.uid
@@ -1,0 +1,1 @@
+uid://bl0rpahl6705g

--- a/tests/unit/test_text_spacing.gd
+++ b/tests/unit/test_text_spacing.gd
@@ -1,0 +1,65 @@
+extends GutTest
+
+## v0.3: letter-spacing and word-spacing render via FontVariation.spacing
+## (no more label.text mutation, no more "stored as meta only" punt).
+## text-indent still has no native Label support and remains metadata only.
+
+
+func _label_with_text(t: String) -> Label:
+	var l := Label.new()
+	l.text = t
+	add_child_autofree(l)
+	return l
+
+
+func test_letter_spacing_wraps_font_in_variation() -> void:
+	var l := _label_with_text("hello")
+	GmlStyles.apply_text_styles(l, {"letter-spacing": 4}, {})
+
+	# Label text must not be mutated.
+	assert_eq(l.text, "hello")
+	# A FontVariation must be installed as the font override.
+	var fv = l.get_theme_font("font")
+	assert_true(fv is FontVariation, "expected FontVariation, got %s" % typeof(fv))
+	assert_eq((fv as FontVariation).spacing_glyph, 4)
+
+
+func test_word_spacing_wraps_font_in_variation() -> void:
+	var l := _label_with_text("a b c")
+	GmlStyles.apply_text_styles(l, {"word-spacing": 6}, {})
+	assert_eq(l.text, "a b c")
+	var fv = l.get_theme_font("font")
+	assert_true(fv is FontVariation)
+	assert_eq((fv as FontVariation).spacing_space, 6)
+
+
+func test_letter_and_word_spacing_share_one_font_variation() -> void:
+	var l := _label_with_text("a b")
+	GmlStyles.apply_text_styles(l, {"letter-spacing": 2, "word-spacing": 6}, {})
+	var fv = l.get_theme_font("font") as FontVariation
+	assert_not_null(fv)
+	assert_eq(fv.spacing_glyph, 2)
+	assert_eq(fv.spacing_space, 6)
+
+
+func test_spacing_layers_over_font_family() -> void:
+	# When the user supplies a font-family, the FontVariation wraps it so the
+	# user's font choice is preserved (not replaced).
+	var custom := SystemFont.new()
+	custom.font_names = PackedStringArray(["sans-serif"])
+	var l := _label_with_text("hi")
+	GmlStyles.apply_text_styles(l, {"font-family": "Custom", "letter-spacing": 3},
+		{"fonts": {"Custom": custom}})
+	var fv = l.get_theme_font("font") as FontVariation
+	assert_not_null(fv)
+	assert_eq(fv.spacing_glyph, 3)
+	assert_eq(fv.base_font, custom, "FontVariation must wrap the user-supplied font")
+
+
+func test_text_indent_still_metadata_only() -> void:
+	# Documented limitation: text-indent has no Label-level native support in
+	# Godot 4, so we keep it as metadata so consumers can post-process if needed.
+	var l := _label_with_text("paragraph")
+	GmlStyles.apply_text_styles(l, {"text-indent": 12}, {})
+	assert_eq(l.text, "paragraph")
+	assert_eq(l.get_meta("text_indent", -1), 12)

--- a/tests/unit/transition_setup_proxy.gd
+++ b/tests/unit/transition_setup_proxy.gd
@@ -1,0 +1,19 @@
+class_name GtmlTransitionSetupTestProxy
+extends RefCounted
+
+## Test-only proxy that exposes GmlTransitionSetup's private helpers so they
+## can be unit-tested without instantiating a Control / SceneTree.
+##
+## Lives under tests/ rather than addons/ so it ships with the test suite,
+## not with the addon itself.
+
+static func strip_state_keys(style: Dictionary) -> Dictionary:
+	return GmlTransitionSetup._strip_state_keys(style)
+
+
+static func collect_state_buckets(style: Dictionary) -> Array:
+	return GmlTransitionSetup._collect_state_buckets(style)
+
+
+static func compute_target(base: Dictionary, buckets: Array, active: Dictionary) -> Dictionary:
+	return GmlTransitionSetup._compute_target(base, buckets, active)

--- a/tests/unit/transition_setup_proxy.gd.uid
+++ b/tests/unit/transition_setup_proxy.gd.uid
@@ -1,0 +1,1 @@
+uid://rbrol4epfb8u


### PR DESCRIPTION
## Summary

Backlog of v0.2's deferred items. 4 commits, 100/100 tests green. Breaking changes documented in `CHANGELOG.md`.

## Phases

1. **Selector extensions** (`GmlSelector`):
   - Sibling combinators `+` (adjacent), `~` (general)
   - Substring attribute matchers `~=`, `^=`, `$=`, `*=`
   - Structural pseudos `:first-child`, `:last-child`, `:only-child`,
     `:nth-child(n|odd|even|an+b)`, `:not(selector)`
   - Matcher refactored to walk a `current_node` + `parent_idx` pair so
     sibling combinators can step across the parent's children without
     losing position in the ancestor chain.

2. **Multi-pseudo combined states**: `button:hover:focus` now resolves into
   a sorted combined bucket (`_focus+hover`) and the renderer applies it
   only when ALL listed states are simultaneously active. `GmlTransitionSetup`
   rewritten around generic state-bucket discovery so any combination of
   tracked states layers correctly.

3. **letter-spacing + word-spacing rendered natively** via `FontVariation`
   (`spacing_glyph` / `spacing_space`). No more `label.text` mutation, no
   more metadata-only placeholder.

4. **Review fixups**: button transitions now honor combined buckets (was a
   blocker — buttons had their own state machine that only knew the legacy
   flat keys). `_nth_matches` uses integer arithmetic. State-bucket sort
   has a deterministic secondary tie-break. Plus 5 missing-coverage tests
   (`:nth-child(2n+1)`, `:nth-child(-n+2)`, `.a+.b` no-spaces parse,
   `:not(:not(.x))` double-negative, `_active`/`_disabled` resolution).

## Stats

| | |
|---|---|
| Tests | 100 (was 64) |
| New selectors | 5 combinators / matchers / 5 structural pseudos |
| Native CSS properties added | letter-spacing, word-spacing |

## Limitations / deferred

- `text-indent` has no native Label support in Godot 4 — still metadata-only.
- `_active` / `_disabled` buckets resolve correctly for all elements but only
  buttons drive `active` (via `button_down`/`button_up`); inputs and anchors
  don't yet emit those signals.

## Test plan

- [ ] `godot --headless -s addons/gut/gut_cmdln.gd -gconfig=res://.gutconfig.json` → 100/100 pass
- [ ] Open the editor, instantiate a `GmlView`, write a stylesheet with `.parent .a + .b:hover { color: red; }` and confirm the matcher hits only the intended elements
- [ ] Author a `button:hover:focus { background-color: ...; }` rule and tab-focus a hovered button — both hover and focus active simultaneously should land on the combined style, not just whichever pseudo fired last
- [ ] Set `letter-spacing: 4px; word-spacing: 8px;` on a paragraph and visually confirm the spacing renders (no longer requires manual integration)