### PR TITLE
v0.3.1: showcase samples + parser robustness + label-for + list dispatch fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## 0.3.1
+
+### Fixes
+
+- **HTML parser termination**: stray closing tags for void elements
+  (`</input>`, `</br>`) are now skipped as no-ops inside parent loops
+  instead of cascading "expected `</X>` but found `</Y>`" warnings and
+  corrupting the DOM. Unmatched closing tags at the top level are
+  consumed cleanly. `parse()` has a defensive cursor-advance guard so
+  it can never spin on a non-advancing return.
+- **`<li>` styling pipeline**: `GmlListBuilder.build_list` used to build
+  list items inline and silently bypass the central dispatcher, so
+  per-item CSS (background, hover transitions, padding, ...) was lost.
+  Items now go through `ctx.build_node` and receive the full styling
+  pipeline. Marker info travels via meta so the list still owns marker
+  resolution.
+- **`<label for>` activation**: clicking a label associated with a
+  CheckBox now toggles it; with a radio in a `ButtonGroup` it selects
+  (never deselects); with a text input or other Control it focuses.
+  Cursor shape on for-labels is set to pointing-hand.
+
+### Samples
+
+- New `addons/gtml/examples/showcase/` directory with three crafted
+  scenes — `atlas` (mission-control dashboard), `atelier` (editorial
+  reader), `forge` (workspace settings) — each demonstrating a distinct
+  aesthetic and exercising a different subset of GTML capabilities.
+
+### Notes
+
+- Anything using `background-color: transparent` that transitions to an
+  opaque color will visibly "flash" through alpha-blended intermediate
+  frames, because the renderer's color tween interpolates alpha as well
+  as RGB. Workaround: use an opaque base color matching the parent
+  surface. Documented in the showcase CSS comments. A proper fix would
+  require pre-compositing the start color against its background before
+  the tween — deferred.
+
+
 ## 0.3.0
 
 ### Features

--- a/addons/gtml/examples/showcase/atelier/demo.tscn
+++ b/addons/gtml/examples/showcase/atelier/demo.tscn
@@ -1,0 +1,31 @@
+[gd_scene load_steps=2 format=3 uid="uid://gml_atelier_demo"]
+
+[ext_resource type="Script" path="res://addons/gtml/src/GmlView.gd" id="1_gmlview"]
+
+[node name="AtelierDemo" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Background" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.960, 0.941, 0.909, 1)
+
+[node name="GmlView" type="Control" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_gmlview")
+html_path = "res://addons/gtml/examples/showcase/atelier/index.html"
+css_path = "res://addons/gtml/examples/showcase/atelier/style.css"

--- a/addons/gtml/examples/showcase/atelier/index.html
+++ b/addons/gtml/examples/showcase/atelier/index.html
@@ -1,0 +1,82 @@
+<div class="page">
+
+  <header class="masthead">
+    <div class="masthead-left">
+      <span class="logo">ATELIER</span>
+      <span class="tagline">journal · craft · design</span>
+    </div>
+    <div class="masthead-right">
+      <span class="issue">ISSUE 14 · SPRING</span>
+    </div>
+  </header>
+
+  <div class="content">
+
+    <article class="essay">
+
+      <div class="essay-meta">
+        <span class="essay-section">ON CRAFT</span>
+        <span class="essay-dot">·</span>
+        <span class="essay-kind">ESSAY</span>
+      </div>
+
+      <h1 class="essay-title">The discipline of quiet tools</h1>
+
+      <p class="essay-deck">A study of the interfaces that disappear into the work — and what we lose when software shouts instead of listens.</p>
+
+      <div class="essay-byline">
+        <span class="byline-name">Jonas Lindqvist</span>
+        <span class="byline-sep">·</span>
+        <span class="byline-time">12 min read</span>
+        <span class="byline-sep">·</span>
+        <span class="byline-date">March 2026</span>
+      </div>
+
+      <div class="essay-body">
+        <p class="lead">There is a kind of software that announces itself constantly. It pulses, it badges, it nudges. It assumes — politely, at first — that you have nothing better to do than respond to it.</p>
+
+        <p>And then there is the other kind. The kind that earns the right to your attention slowly, by being so quiet that you forget it is there until you need it.</p>
+
+        <p>The discipline of quiet tools is mostly the discipline of restraint. Every notification justified. Every animation slow enough to be ignored. Every default chosen by someone who had to live with it.</p>
+
+        <p>The quiet tool does not perform. It does not flatter. It does its job and steps back so you can do yours. The work — your work — remains the center of gravity.</p>
+
+        <p class="callout">"The best interface is the one you stop noticing on the third day."</p>
+
+        <p>This is harder to design than it looks. A loud product can hide a thin idea. A quiet product cannot. Every surface that disappears is a surface that had to be considered hard enough to know that disappearing was the point.</p>
+      </div>
+
+    </article>
+
+    <aside class="sidebar">
+
+      <section class="side-block">
+        <h3 class="side-heading">SECTIONS</h3>
+        <ul class="side-list">
+          <li class="side-item side-active">Process</li>
+          <li class="side-item">Materials</li>
+          <li class="side-item">Voice</li>
+          <li class="side-item">Restraint</li>
+          <li class="side-item">Surface</li>
+        </ul>
+      </section>
+
+      <section class="side-block">
+        <h3 class="side-heading">RELATED</h3>
+        <ul class="side-list">
+          <li class="side-item-link">The anti-default movement</li>
+          <li class="side-item-link">Density as a discipline</li>
+          <li class="side-item-link">In defense of borders</li>
+        </ul>
+      </section>
+
+      <section class="side-block side-block-quiet">
+        <h3 class="side-heading">FROM THE EDITOR</h3>
+        <p class="side-note">This issue celebrates the makers who refuse to ship the obvious answer. Subscribe to receive the next four issues by post.</p>
+      </section>
+
+    </aside>
+
+  </div>
+
+</div>

--- a/addons/gtml/examples/showcase/atelier/style.css
+++ b/addons/gtml/examples/showcase/atelier/style.css
@@ -1,0 +1,290 @@
+/* Atelier — editorial reader
+ * Editorial / magazine. Warm cream surface, deep ink text. Single rust accent.
+ * Surface-color hierarchy for depth (no shadows, no borders on the body).
+ * Generous 16/24/32/48 spacing. Letter-spaced eyebrows show off v0.3.
+ */
+
+.page {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    background-color: #f5f0e8;
+    color: #1a1612;
+}
+
+/* ─── Masthead ──────────────────────────────────────── */
+
+.masthead {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    padding-left: 48px;
+    padding-right: 48px;
+    padding-top: 24px;
+    padding-bottom: 24px;
+    border-bottom: 1px solid #d8cfc0;
+}
+
+.masthead-left {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 24px;
+}
+
+.logo {
+    font-size: 18px;
+    color: #1a1612;
+    font-weight: 700;
+    letter-spacing: 6;
+}
+
+.tagline {
+    font-size: 11px;
+    color: #6e6457;
+    letter-spacing: 2;
+    text-transform: uppercase;
+    font-weight: 500;
+}
+
+.masthead-right {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.issue {
+    font-size: 11px;
+    color: #a8451f;
+    letter-spacing: 3;
+    font-weight: 600;
+}
+
+/* ─── Content split ─────────────────────────────────── */
+
+.content {
+    display: flex;
+    flex-direction: row;
+    flex-grow: 1;
+    overflow: hidden;
+}
+
+/* ─── Essay column ──────────────────────────────────── */
+
+.essay {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    padding-left: 80px;
+    padding-right: 80px;
+    padding-top: 56px;
+    padding-bottom: 56px;
+    gap: 24px;
+    overflow-y: auto;
+    max-width: 720px;
+}
+
+.essay-meta {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
+}
+
+.essay-section {
+    font-size: 11px;
+    color: #a8451f;
+    letter-spacing: 4;
+    font-weight: 700;
+}
+
+.essay-dot {
+    color: #c4b8a4;
+    font-size: 12px;
+}
+
+.essay-kind {
+    font-size: 11px;
+    color: #6e6457;
+    letter-spacing: 4;
+    font-weight: 600;
+}
+
+.essay-title {
+    font-size: 48px;
+    color: #1a1612;
+    font-weight: 700;
+    line-height: 4;
+    margin-bottom: 8px;
+}
+
+.essay-deck {
+    font-size: 18px;
+    color: #4a4035;
+    line-height: 8;
+    font-weight: 400;
+    margin-bottom: 16px;
+}
+
+.essay-byline {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+    padding-bottom: 24px;
+    border-bottom: 1px solid #d8cfc0;
+    margin-bottom: 16px;
+}
+
+.byline-name {
+    font-size: 12px;
+    color: #1a1612;
+    font-weight: 600;
+    letter-spacing: 1;
+}
+
+.byline-sep {
+    color: #c4b8a4;
+    font-size: 11px;
+}
+
+.byline-time {
+    font-size: 11px;
+    color: #6e6457;
+    letter-spacing: 1;
+}
+
+.byline-date {
+    font-size: 11px;
+    color: #6e6457;
+    letter-spacing: 1;
+}
+
+.essay-body {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.lead {
+    font-size: 17px;
+    color: #2a2218;
+    line-height: 9;
+    font-weight: 500;
+}
+
+.essay-body p {
+    font-size: 15px;
+    color: #2a2218;
+    line-height: 10;
+}
+
+.callout {
+    font-size: 20px;
+    color: #a8451f;
+    font-weight: 600;
+    line-height: 6;
+    padding-top: 16px;
+    padding-bottom: 16px;
+    padding-left: 24px;
+    border-left: 3px solid #a8451f;
+    margin-top: 16px;
+    margin-bottom: 16px;
+}
+
+/* ─── Sidebar ───────────────────────────────────────── */
+
+.sidebar {
+    display: flex;
+    flex-direction: column;
+    width: 280px;
+    background-color: #ebe3d4;
+    padding-left: 32px;
+    padding-right: 32px;
+    padding-top: 56px;
+    padding-bottom: 56px;
+    gap: 40px;
+    border-left: 1px solid #d8cfc0;
+    /* Sidebar content can exceed viewport height — scroll independently of
+       the essay column so neither falls off the bottom. */
+    overflow-y: auto;
+}
+
+.side-block {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.side-heading {
+    font-size: 11px;
+    color: #6e6457;
+    letter-spacing: 4;
+    font-weight: 700;
+    padding-bottom: 8px;
+    border-bottom: 1px solid #c4b8a4;
+    margin-bottom: 4px;
+}
+
+.side-list {
+    display: flex;
+    flex-direction: column;
+    list-style-type: none;
+    gap: 2px;
+}
+
+.side-item {
+    font-size: 13px;
+    color: #2a2218;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    padding-left: 12px;
+    padding-right: 12px;
+    border-radius: 2px;
+    /* Opaque base matches the sidebar so hover interpolates clean. */
+    background-color: #ebe3d4;
+    transition: background-color 180ms, color 180ms;
+}
+
+.side-item:hover {
+    background-color: #ddd3c0;
+}
+
+.side-active {
+    color: #a8451f;
+    font-weight: 600;
+    border-left: 2px solid #a8451f;
+    padding-left: 10px;
+}
+
+.side-item-link {
+    font-size: 13px;
+    color: #4a4035;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    padding-left: 12px;
+    padding-right: 12px;
+    border-radius: 2px;
+    background-color: #ebe3d4;
+    border-bottom: 1px solid #ddd3c0;
+    transition: color 180ms, border-bottom 180ms;
+}
+
+.side-item-link:hover {
+    color: #a8451f;
+    border-bottom: 1px solid #a8451f;
+}
+
+.side-block-quiet {
+    background-color: #e0d8c8;
+    padding: 20px;
+    border-radius: 2px;
+}
+
+.side-note {
+    font-size: 12px;
+    color: #4a4035;
+    line-height: 8;
+}

--- a/addons/gtml/examples/showcase/atlas/demo.tscn
+++ b/addons/gtml/examples/showcase/atlas/demo.tscn
@@ -1,0 +1,31 @@
+[gd_scene load_steps=2 format=3 uid="uid://gml_atlas_demo"]
+
+[ext_resource type="Script" path="res://addons/gtml/src/GmlView.gd" id="1_gmlview"]
+
+[node name="AtlasDemo" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Background" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.039, 0.054, 0.101, 1)
+
+[node name="GmlView" type="Control" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_gmlview")
+html_path = "res://addons/gtml/examples/showcase/atlas/index.html"
+css_path = "res://addons/gtml/examples/showcase/atlas/style.css"

--- a/addons/gtml/examples/showcase/atlas/index.html
+++ b/addons/gtml/examples/showcase/atlas/index.html
@@ -1,0 +1,140 @@
+<div class="app">
+
+  <header class="topbar">
+    <div class="brand-block">
+      <span class="brand-mark">atlas</span>
+      <span class="brand-sep">/</span>
+      <span class="brand-context">orbital ops</span>
+    </div>
+    <div class="topbar-right">
+      <div class="status-pill">
+        <span class="status-dot"></span>
+        <span class="status-label">all systems nominal</span>
+      </div>
+      <div class="user-chip">jl · ops</div>
+    </div>
+  </header>
+
+  <div class="shell">
+
+    <nav class="sidebar">
+      <div class="nav-section">
+        <span class="nav-label">workspace</span>
+        <a class="nav-item nav-active">Mission control</a>
+        <a class="nav-item">Activity feed</a>
+        <a class="nav-item">Alerts</a>
+      </div>
+      <div class="nav-section">
+        <span class="nav-label">infrastructure</span>
+        <a class="nav-item">Nodes</a>
+        <a class="nav-item">Telemetry</a>
+        <a class="nav-item">Configuration</a>
+      </div>
+      <div class="nav-section">
+        <span class="nav-label">archive</span>
+        <a class="nav-item">Incident log</a>
+        <a class="nav-item">Reports</a>
+      </div>
+    </nav>
+
+    <main class="main">
+
+      <div class="page-head">
+        <div class="page-head-text">
+          <span class="eyebrow">DASHBOARD</span>
+          <h1 class="page-title">Mission control</h1>
+          <p class="page-subtitle">Real-time visibility into the production fleet across all regions.</p>
+        </div>
+        <button class="primary-action">Trigger sweep</button>
+      </div>
+
+      <section class="kpi-row">
+        <article class="kpi">
+          <span class="kpi-label">Active nodes</span>
+          <span class="kpi-value">142</span>
+          <span class="kpi-delta delta-up">+3 since 09:00</span>
+        </article>
+        <article class="kpi">
+          <span class="kpi-label">Uptime</span>
+          <span class="kpi-value">99.84</span>
+          <span class="kpi-delta delta-flat">30-day rolling</span>
+        </article>
+        <article class="kpi">
+          <span class="kpi-label">Median latency</span>
+          <span class="kpi-value">17ms</span>
+          <span class="kpi-delta delta-down">-2ms vs yesterday</span>
+        </article>
+        <article class="kpi">
+          <span class="kpi-label">Open alerts</span>
+          <span class="kpi-value kpi-warn">3</span>
+          <span class="kpi-delta delta-flat">1 high severity</span>
+        </article>
+      </section>
+
+      <section class="grid-split">
+
+        <article class="card">
+          <header class="card-head">
+            <h2 class="card-title">Recent activity</h2>
+            <span class="card-meta">last 30 minutes</span>
+          </header>
+          <ul class="activity">
+            <li class="activity-item">
+              <span class="activity-time">12:48</span>
+              <span class="activity-text">node-04 reconnected after maintenance window</span>
+            </li>
+            <li class="activity-item">
+              <span class="activity-time">12:31</span>
+              <span class="activity-text">alert ALR-2841 resolved by m.tanaka</span>
+            </li>
+            <li class="activity-item">
+              <span class="activity-time">12:19</span>
+              <span class="activity-text">node-12 joined eu-west cluster</span>
+            </li>
+            <li class="activity-item">
+              <span class="activity-time">12:02</span>
+              <span class="activity-text">scheduled sweep completed in 1.4s</span>
+            </li>
+            <li class="activity-item">
+              <span class="activity-time">11:47</span>
+              <span class="activity-text">configuration deployed to 142 nodes</span>
+            </li>
+          </ul>
+        </article>
+
+        <article class="card">
+          <header class="card-head">
+            <h2 class="card-title">System status</h2>
+            <span class="card-meta">live</span>
+          </header>
+          <ul class="status-list">
+            <li class="status-row">
+              <span class="status-name">API gateway</span>
+              <span class="status-badge badge-ok">OPERATIONAL</span>
+            </li>
+            <li class="status-row">
+              <span class="status-name">Database replica</span>
+              <span class="status-badge badge-ok">OPERATIONAL</span>
+            </li>
+            <li class="status-row">
+              <span class="status-name">Edge CDN</span>
+              <span class="status-badge badge-warn">DEGRADED</span>
+            </li>
+            <li class="status-row">
+              <span class="status-name">Auth provider</span>
+              <span class="status-badge badge-ok">OPERATIONAL</span>
+            </li>
+            <li class="status-row">
+              <span class="status-name">Webhook dispatcher</span>
+              <span class="status-badge badge-ok">OPERATIONAL</span>
+            </li>
+          </ul>
+        </article>
+
+      </section>
+
+    </main>
+
+  </div>
+
+</div>

--- a/addons/gtml/examples/showcase/atlas/style.css
+++ b/addons/gtml/examples/showcase/atlas/style.css
@@ -1,0 +1,418 @@
+/* Atlas — mission-control dashboard
+ * Precision + density. Cool slate neutrals. Single cyan accent reserved for
+ * live signal and primary action. Borders only, no shadows. 8/16/24 grid.
+ */
+
+.app {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    background-color: #0a0e1a;
+    color: #c8cfdd;
+}
+
+/* ─── Topbar ────────────────────────────────────────── */
+
+.topbar {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    padding-left: 24px;
+    padding-right: 24px;
+    padding-top: 14px;
+    padding-bottom: 14px;
+    border-bottom: 1px solid #1a2236;
+    background-color: #0c1120;
+}
+
+.brand-block {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 10px;
+}
+
+.brand-mark {
+    font-size: 14px;
+    font-weight: 700;
+    color: #ffffff;
+    letter-spacing: 2;
+    text-transform: uppercase;
+}
+
+.brand-sep {
+    color: #3a4663;
+    font-size: 14px;
+}
+
+.brand-context {
+    font-size: 13px;
+    color: #8a93a8;
+    letter-spacing: 1;
+}
+
+.topbar-right {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 16px;
+}
+
+.status-pill {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+    padding-left: 12px;
+    padding-right: 12px;
+    padding-top: 6px;
+    padding-bottom: 6px;
+    border: 1px solid #1f3045;
+    border-radius: 999px;
+    background-color: #0e1828;
+}
+
+.status-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 3px;
+    background-color: #5fc8ff;
+}
+
+.status-label {
+    font-size: 12px;
+    color: #5fc8ff;
+    letter-spacing: 1;
+    text-transform: uppercase;
+    font-weight: 600;
+}
+
+.user-chip {
+    font-size: 12px;
+    color: #8a93a8;
+    padding-left: 10px;
+    padding-right: 10px;
+    padding-top: 6px;
+    padding-bottom: 6px;
+    border: 1px solid #1f2a3f;
+    border-radius: 4px;
+    letter-spacing: 1;
+}
+
+/* ─── Shell ──────────────────────────────────────────── */
+
+.shell {
+    display: flex;
+    flex-direction: row;
+    flex-grow: 1;
+    overflow: hidden;
+}
+
+/* ─── Sidebar ───────────────────────────────────────── */
+
+.sidebar {
+    display: flex;
+    flex-direction: column;
+    width: 224px;
+    background-color: #0c1120;
+    border-right: 1px solid #1a2236;
+    padding: 16px;
+    gap: 24px;
+}
+
+.nav-section {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.nav-label {
+    font-size: 11px;
+    color: #4a5670;
+    letter-spacing: 1;
+    text-transform: uppercase;
+    font-weight: 600;
+    padding-left: 12px;
+    padding-bottom: 8px;
+}
+
+.nav-item {
+    display: block;
+    font-size: 13px;
+    color: #8a93a8;
+    padding-left: 12px;
+    padding-right: 12px;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    border-radius: 4px;
+    /* Match the sidebar surface so hover interpolates between opaque colors
+       only — transparent->opaque produces a gray "alpha flash" mid-transition. */
+    background-color: #0c1120;
+    transition: background-color 150ms, color 150ms;
+}
+
+.nav-item:hover {
+    background-color: #131a2e;
+    color: #c8cfdd;
+}
+
+.nav-active {
+    background-color: #131a2e;
+    color: #ffffff;
+    border-left: 2px solid #5fc8ff;
+    padding-left: 10px;
+}
+
+/* ─── Main column ───────────────────────────────────── */
+
+.main {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    padding: 32px;
+    gap: 24px;
+    overflow-y: auto;
+}
+
+.page-head {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    padding-bottom: 8px;
+}
+
+.page-head-text {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.eyebrow {
+    font-size: 11px;
+    color: #5fc8ff;
+    letter-spacing: 3;
+    text-transform: uppercase;
+    font-weight: 600;
+}
+
+.page-title {
+    font-size: 28px;
+    color: #ffffff;
+    font-weight: 700;
+}
+
+.page-subtitle {
+    font-size: 13px;
+    color: #6c7691;
+}
+
+.primary-action {
+    background-color: #5fc8ff;
+    color: #0a0e1a;
+    border: none;
+    border-radius: 4px;
+    padding-left: 16px;
+    padding-right: 16px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 1;
+    text-transform: uppercase;
+    transition: background-color 180ms;
+}
+
+.primary-action:hover {
+    background-color: #8edaff;
+}
+
+/* ─── KPI row ───────────────────────────────────────── */
+
+.kpi-row {
+    display: flex;
+    flex-direction: row;
+    gap: 16px;
+}
+
+.kpi {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    gap: 8px;
+    padding: 20px;
+    border: 1px solid #1a2236;
+    border-radius: 6px;
+    background-color: #0e1322;
+}
+
+.kpi-label {
+    font-size: 11px;
+    color: #6c7691;
+    letter-spacing: 2;
+    text-transform: uppercase;
+    font-weight: 600;
+}
+
+.kpi-value {
+    font-size: 32px;
+    color: #ffffff;
+    font-weight: 700;
+}
+
+.kpi-warn {
+    color: #ffb454;
+}
+
+.kpi-delta {
+    font-size: 11px;
+    color: #5a6480;
+    letter-spacing: 1;
+}
+
+.delta-up {
+    color: #6dd198;
+}
+
+.delta-down {
+    color: #5fc8ff;
+}
+
+.delta-flat {
+    color: #5a6480;
+}
+
+/* ─── Card grid ─────────────────────────────────────── */
+
+.grid-split {
+    display: flex;
+    flex-direction: row;
+    gap: 16px;
+}
+
+.card {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    border: 1px solid #1a2236;
+    border-radius: 6px;
+    background-color: #0e1322;
+}
+
+.card-head {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px;
+    border-bottom: 1px solid #1a2236;
+}
+
+.card-title {
+    font-size: 14px;
+    color: #ffffff;
+    font-weight: 600;
+}
+
+.card-meta {
+    font-size: 11px;
+    color: #5a6480;
+    letter-spacing: 2;
+    text-transform: uppercase;
+}
+
+/* ─── Activity list ─────────────────────────────────── */
+
+.activity {
+    display: flex;
+    flex-direction: column;
+    padding: 8px;
+    gap: 0;
+    list-style-type: none;
+}
+
+.activity-item {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 16px;
+    padding: 12px;
+    border-radius: 4px;
+    /* Opaque base color so the hover transition doesn't pass through an
+       alpha-blended intermediate. Matches the surrounding card surface. */
+    background-color: #0e1322;
+    transition: background-color 150ms;
+}
+
+.activity-item:hover {
+    background-color: #131a2e;
+}
+
+.activity-time {
+    font-size: 12px;
+    color: #5a6480;
+    letter-spacing: 1;
+    min-width: 44px;
+    font-weight: 600;
+}
+
+.activity-text {
+    font-size: 13px;
+    color: #c8cfdd;
+}
+
+/* ─── Status list ───────────────────────────────────── */
+
+.status-list {
+    display: flex;
+    flex-direction: column;
+    list-style-type: none;
+    padding-top: 8px;
+    padding-bottom: 8px;
+}
+
+.status-row {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    padding-left: 20px;
+    padding-right: 20px;
+    padding-top: 12px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid #141b2e;
+}
+
+.status-row:last-child {
+    border-bottom: 0;
+}
+
+.status-name {
+    font-size: 13px;
+    color: #c8cfdd;
+}
+
+.status-badge {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 1;
+    padding-left: 8px;
+    padding-right: 8px;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    border-radius: 3px;
+}
+
+.badge-ok {
+    background-color: #112d22;
+    color: #6dd198;
+    border: 1px solid #1f4836;
+}
+
+.badge-warn {
+    background-color: #2d2418;
+    color: #ffb454;
+    border: 1px solid #4d3c1f;
+}

--- a/addons/gtml/examples/showcase/forge/demo.tscn
+++ b/addons/gtml/examples/showcase/forge/demo.tscn
@@ -1,0 +1,31 @@
+[gd_scene load_steps=2 format=3 uid="uid://gml_forge_demo"]
+
+[ext_resource type="Script" path="res://addons/gtml/src/GmlView.gd" id="1_gmlview"]
+
+[node name="ForgeDemo" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Background" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.050, 0.050, 0.050, 1)
+
+[node name="GmlView" type="Control" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_gmlview")
+html_path = "res://addons/gtml/examples/showcase/forge/index.html"
+css_path = "res://addons/gtml/examples/showcase/forge/style.css"

--- a/addons/gtml/examples/showcase/forge/index.html
+++ b/addons/gtml/examples/showcase/forge/index.html
@@ -49,20 +49,20 @@
         </header>
 
         <div class="field">
-          <label class="field-label">Workspace name</label>
-          <input class="field-input" type="text" value="Acme Industries">
+          <label class="field-label" for="workspace-name">Workspace name</label>
+          <input id="workspace-name" class="field-input" type="text" value="Acme Industries">
           <span class="field-hint">Shown in the topbar, billing receipts, and the API.</span>
         </div>
 
         <div class="field">
-          <label class="field-label">Slug</label>
-          <input class="field-input" type="text" value="acme-industries">
+          <label class="field-label" for="workspace-slug">Slug</label>
+          <input id="workspace-slug" class="field-input" type="text" value="acme-industries">
           <span class="field-hint">Used in URLs. Lowercase, no spaces, hyphens allowed.</span>
         </div>
 
         <div class="field">
-          <label class="field-label">Region</label>
-          <input class="field-input" type="text" value="eu-west-1">
+          <label class="field-label" for="workspace-region">Region</label>
+          <input id="workspace-region" class="field-input" type="text" value="eu-west-1">
           <span class="field-hint">Data residency cannot be changed after creation.</span>
         </div>
       </section>
@@ -76,25 +76,25 @@
         </header>
 
         <div class="check-row">
-          <input class="check-box" type="checkbox" checked>
+          <input id="notify-email" class="check-box" type="checkbox" checked>
           <div class="check-text">
-            <span class="check-label">Email notifications</span>
+            <label class="check-label" for="notify-email">Email notifications</label>
             <span class="check-help">Receive a digest of mentions, comments, and alerts twice daily.</span>
           </div>
         </div>
 
         <div class="check-row">
-          <input class="check-box" type="checkbox">
+          <input id="notify-slack" class="check-box" type="checkbox">
           <div class="check-text">
-            <span class="check-label">Slack notifications</span>
+            <label class="check-label" for="notify-slack">Slack notifications</label>
             <span class="check-help">Mirror your inbox into the configured Slack channel.</span>
           </div>
         </div>
 
         <div class="check-row">
-          <input class="check-box" type="checkbox" checked>
+          <input id="notify-weekly" class="check-box" type="checkbox" checked>
           <div class="check-text">
-            <span class="check-label">Weekly summary</span>
+            <label class="check-label" for="notify-weekly">Weekly summary</label>
             <span class="check-help">A Monday-morning recap of the previous week's activity.</span>
           </div>
         </div>
@@ -109,25 +109,25 @@
         </header>
 
         <div class="radio-row">
-          <input class="radio-dot" type="radio" name="archive">
+          <input id="archive-keep" class="radio-dot" type="radio" name="archive">
           <div class="radio-text">
-            <span class="radio-label">Keep everything indefinitely</span>
+            <label class="radio-label" for="archive-keep">Keep everything indefinitely</label>
             <span class="radio-help">Best for compliance-heavy workspaces.</span>
           </div>
         </div>
 
         <div class="radio-row">
-          <input class="radio-dot" type="radio" name="archive" checked>
+          <input id="archive-auto" class="radio-dot" type="radio" name="archive" checked>
           <div class="radio-text">
-            <span class="radio-label">Auto-archive after 30 days of inactivity</span>
+            <label class="radio-label" for="archive-auto">Auto-archive after 30 days of inactivity</label>
             <span class="radio-help">Recommended for most teams.</span>
           </div>
         </div>
 
         <div class="radio-row">
-          <input class="radio-dot" type="radio" name="archive">
+          <input id="archive-manual" class="radio-dot" type="radio" name="archive">
           <div class="radio-text">
-            <span class="radio-label">Manual archive only</span>
+            <label class="radio-label" for="archive-manual">Manual archive only</label>
             <span class="radio-help">Nothing is hidden without an explicit action.</span>
           </div>
         </div>

--- a/addons/gtml/examples/showcase/forge/index.html
+++ b/addons/gtml/examples/showcase/forge/index.html
@@ -75,29 +75,29 @@
           <p class="section-help">Per-user defaults you can override anytime.</p>
         </header>
 
-        <div class="check-row">
+        <label class="check-row" for="notify-email">
           <input id="notify-email" class="check-box" type="checkbox" checked>
           <div class="check-text">
-            <label class="check-label" for="notify-email">Email notifications</label>
+            <span class="check-label">Email notifications</span>
             <span class="check-help">Receive a digest of mentions, comments, and alerts twice daily.</span>
           </div>
-        </div>
+        </label>
 
-        <div class="check-row">
+        <label class="check-row" for="notify-slack">
           <input id="notify-slack" class="check-box" type="checkbox">
           <div class="check-text">
-            <label class="check-label" for="notify-slack">Slack notifications</label>
+            <span class="check-label">Slack notifications</span>
             <span class="check-help">Mirror your inbox into the configured Slack channel.</span>
           </div>
-        </div>
+        </label>
 
-        <div class="check-row">
+        <label class="check-row" for="notify-weekly">
           <input id="notify-weekly" class="check-box" type="checkbox" checked>
           <div class="check-text">
-            <label class="check-label" for="notify-weekly">Weekly summary</label>
+            <span class="check-label">Weekly summary</span>
             <span class="check-help">A Monday-morning recap of the previous week's activity.</span>
           </div>
-        </div>
+        </label>
       </section>
 
       <div class="section-divider"></div>
@@ -108,29 +108,29 @@
           <p class="section-help">How long inactive projects remain visible in your workspace.</p>
         </header>
 
-        <div class="radio-row">
+        <label class="radio-row" for="archive-keep">
           <input id="archive-keep" class="radio-dot" type="radio" name="archive">
           <div class="radio-text">
-            <label class="radio-label" for="archive-keep">Keep everything indefinitely</label>
+            <span class="radio-label">Keep everything indefinitely</span>
             <span class="radio-help">Best for compliance-heavy workspaces.</span>
           </div>
-        </div>
+        </label>
 
-        <div class="radio-row">
+        <label class="radio-row" for="archive-auto">
           <input id="archive-auto" class="radio-dot" type="radio" name="archive" checked>
           <div class="radio-text">
-            <label class="radio-label" for="archive-auto">Auto-archive after 30 days of inactivity</label>
+            <span class="radio-label">Auto-archive after 30 days of inactivity</span>
             <span class="radio-help">Recommended for most teams.</span>
           </div>
-        </div>
+        </label>
 
-        <div class="radio-row">
+        <label class="radio-row" for="archive-manual">
           <input id="archive-manual" class="radio-dot" type="radio" name="archive">
           <div class="radio-text">
-            <label class="radio-label" for="archive-manual">Manual archive only</label>
+            <span class="radio-label">Manual archive only</span>
             <span class="radio-help">Nothing is hidden without an explicit action.</span>
           </div>
-        </div>
+        </label>
       </section>
 
     </main>

--- a/addons/gtml/examples/showcase/forge/index.html
+++ b/addons/gtml/examples/showcase/forge/index.html
@@ -1,0 +1,140 @@
+<div class="app">
+
+  <header class="topbar">
+    <div class="topbar-left">
+      <span class="brand">Forge</span>
+      <span class="brand-divider">/</span>
+      <span class="crumb">Workspace settings</span>
+    </div>
+    <div class="topbar-actions">
+      <button class="btn btn-ghost">Cancel</button>
+      <button class="btn btn-primary">Save changes</button>
+    </div>
+  </header>
+
+  <div class="shell">
+
+    <nav class="sidenav">
+
+      <div class="nav-group">
+        <span class="nav-group-label">Workspace</span>
+        <a class="nav-link nav-link-active">Account</a>
+        <a class="nav-link">Members</a>
+        <a class="nav-link">Billing</a>
+        <a class="nav-link">Audit log</a>
+      </div>
+
+      <div class="nav-group">
+        <span class="nav-group-label">Develop</span>
+        <a class="nav-link">API keys</a>
+        <a class="nav-link">Webhooks</a>
+        <a class="nav-link">Integrations</a>
+      </div>
+
+      <div class="nav-group">
+        <span class="nav-group-label">Security</span>
+        <a class="nav-link">Two-factor auth</a>
+        <a class="nav-link">Active sessions</a>
+        <a class="nav-link">SSO</a>
+      </div>
+
+    </nav>
+
+    <main class="panel">
+
+      <section class="form-section">
+        <header class="section-head">
+          <h2 class="section-title">Identity</h2>
+          <p class="section-help">How your workspace is referenced across the product.</p>
+        </header>
+
+        <div class="field">
+          <label class="field-label">Workspace name</label>
+          <input class="field-input" type="text" value="Acme Industries">
+          <span class="field-hint">Shown in the topbar, billing receipts, and the API.</span>
+        </div>
+
+        <div class="field">
+          <label class="field-label">Slug</label>
+          <input class="field-input" type="text" value="acme-industries">
+          <span class="field-hint">Used in URLs. Lowercase, no spaces, hyphens allowed.</span>
+        </div>
+
+        <div class="field">
+          <label class="field-label">Region</label>
+          <input class="field-input" type="text" value="eu-west-1">
+          <span class="field-hint">Data residency cannot be changed after creation.</span>
+        </div>
+      </section>
+
+      <div class="section-divider"></div>
+
+      <section class="form-section">
+        <header class="section-head">
+          <h2 class="section-title">Preferences</h2>
+          <p class="section-help">Per-user defaults you can override anytime.</p>
+        </header>
+
+        <div class="check-row">
+          <input class="check-box" type="checkbox" checked>
+          <div class="check-text">
+            <span class="check-label">Email notifications</span>
+            <span class="check-help">Receive a digest of mentions, comments, and alerts twice daily.</span>
+          </div>
+        </div>
+
+        <div class="check-row">
+          <input class="check-box" type="checkbox">
+          <div class="check-text">
+            <span class="check-label">Slack notifications</span>
+            <span class="check-help">Mirror your inbox into the configured Slack channel.</span>
+          </div>
+        </div>
+
+        <div class="check-row">
+          <input class="check-box" type="checkbox" checked>
+          <div class="check-text">
+            <span class="check-label">Weekly summary</span>
+            <span class="check-help">A Monday-morning recap of the previous week's activity.</span>
+          </div>
+        </div>
+      </section>
+
+      <div class="section-divider"></div>
+
+      <section class="form-section">
+        <header class="section-head">
+          <h2 class="section-title">Archival policy</h2>
+          <p class="section-help">How long inactive projects remain visible in your workspace.</p>
+        </header>
+
+        <div class="radio-row">
+          <input class="radio-dot" type="radio" name="archive">
+          <div class="radio-text">
+            <span class="radio-label">Keep everything indefinitely</span>
+            <span class="radio-help">Best for compliance-heavy workspaces.</span>
+          </div>
+        </div>
+
+        <div class="radio-row">
+          <input class="radio-dot" type="radio" name="archive" checked>
+          <div class="radio-text">
+            <span class="radio-label">Auto-archive after 30 days of inactivity</span>
+            <span class="radio-help">Recommended for most teams.</span>
+          </div>
+        </div>
+
+        <div class="radio-row">
+          <input class="radio-dot" type="radio" name="archive">
+          <div class="radio-text">
+            <span class="radio-label">Manual archive only</span>
+            <span class="radio-help">Nothing is hidden without an explicit action.</span>
+          </div>
+        </div>
+      </section>
+
+    </main>
+
+  </div>
+
+</div>

--- a/addons/gtml/examples/showcase/forge/style.css
+++ b/addons/gtml/examples/showcase/forge/style.css
@@ -273,6 +273,11 @@
     height: 18px;
 }
 
+.check-box:focus {
+    border: 1px solid #9b7eff;
+    border-radius: 3px;
+}
+
 .check-text {
     display: flex;
     flex-direction: column;
@@ -312,6 +317,11 @@
 .radio-dot {
     width: 18px;
     height: 18px;
+}
+
+.radio-dot:focus {
+    border: 1px solid #9b7eff;
+    border-radius: 9px;
 }
 
 .radio-text {

--- a/addons/gtml/examples/showcase/forge/style.css
+++ b/addons/gtml/examples/showcase/forge/style.css
@@ -1,0 +1,332 @@
+/* Forge — workspace settings
+ * Utility + function. Pure neutral dark, single electric-violet accent.
+ * Borders-only depth, custom-styled inputs with deliberate focus rings.
+ * 8/16/24 grid throughout. Showcases v0.3 multi-pseudo button transitions.
+ */
+
+.app {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    background-color: #0d0d0d;
+    color: #d4d4d4;
+}
+
+/* ─── Topbar ────────────────────────────────────────── */
+
+.topbar {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    padding-left: 24px;
+    padding-right: 24px;
+    padding-top: 14px;
+    padding-bottom: 14px;
+    border-bottom: 1px solid #1f1f1f;
+    background-color: #111111;
+}
+
+.topbar-left {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
+}
+
+.brand {
+    font-size: 14px;
+    color: #ffffff;
+    font-weight: 700;
+    letter-spacing: 1;
+}
+
+.brand-divider {
+    color: #3a3a3a;
+    font-size: 14px;
+}
+
+.crumb {
+    font-size: 13px;
+    color: #8a8a8a;
+}
+
+.topbar-actions {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+}
+
+.btn {
+    border: 1px solid #2a2a2a;
+    border-radius: 4px;
+    padding-left: 14px;
+    padding-right: 14px;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    font-size: 13px;
+    font-weight: 600;
+    transition: background-color 180ms, border 180ms, color 180ms;
+}
+
+.btn-ghost {
+    /* Match the topbar surface so hover interpolates opaque->opaque. */
+    background-color: #111111;
+    color: #d4d4d4;
+}
+
+.btn-ghost:hover {
+    background-color: #1a1a1a;
+    border: 1px solid #3a3a3a;
+}
+
+.btn-primary {
+    background-color: #9b7eff;
+    color: #0d0d0d;
+    border: 1px solid #9b7eff;
+}
+
+.btn-primary:hover {
+    background-color: #b39dff;
+    border: 1px solid #b39dff;
+}
+
+.btn-primary:focus {
+    border: 1px solid #d4c8ff;
+}
+
+/* ─── Shell ──────────────────────────────────────────── */
+
+.shell {
+    display: flex;
+    flex-direction: row;
+    flex-grow: 1;
+    overflow: hidden;
+}
+
+/* ─── Sidenav ────────────────────────────────────────── */
+
+.sidenav {
+    display: flex;
+    flex-direction: column;
+    width: 220px;
+    background-color: #111111;
+    border-right: 1px solid #1f1f1f;
+    padding: 16px;
+    gap: 24px;
+}
+
+.nav-group {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.nav-group-label {
+    font-size: 10px;
+    color: #5a5a5a;
+    letter-spacing: 3;
+    text-transform: uppercase;
+    font-weight: 700;
+    padding-left: 12px;
+    padding-bottom: 8px;
+}
+
+.nav-link {
+    display: block;
+    font-size: 13px;
+    color: #8a8a8a;
+    padding-left: 12px;
+    padding-right: 12px;
+    padding-top: 7px;
+    padding-bottom: 7px;
+    border-radius: 4px;
+    /* Match the sidenav surface so hover doesn't flash through alpha. */
+    background-color: #111111;
+    transition: background-color 150ms, color 150ms;
+}
+
+.nav-link:hover {
+    background-color: #1a1a1a;
+    color: #d4d4d4;
+}
+
+.nav-link-active {
+    background-color: #1f1a2e;
+    color: #b39dff;
+    border-left: 2px solid #9b7eff;
+    padding-left: 10px;
+    font-weight: 600;
+}
+
+/* ─── Panel ──────────────────────────────────────────── */
+
+.panel {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    padding-left: 48px;
+    padding-right: 48px;
+    padding-top: 40px;
+    padding-bottom: 40px;
+    gap: 32px;
+    overflow-y: auto;
+    max-width: 720px;
+}
+
+.section-divider {
+    height: 1px;
+    background-color: #1f1f1f;
+}
+
+.form-section {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.section-head {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding-bottom: 4px;
+}
+
+.section-title {
+    font-size: 18px;
+    color: #ffffff;
+    font-weight: 600;
+    letter-spacing: 0;
+}
+
+.section-help {
+    font-size: 13px;
+    color: #6a6a6a;
+}
+
+/* ─── Field ──────────────────────────────────────────── */
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.field-label {
+    font-size: 12px;
+    color: #b8b8b8;
+    font-weight: 600;
+    letter-spacing: 1;
+}
+
+.field-input {
+    background-color: #161616;
+    color: #ffffff;
+    border: 1px solid #2a2a2a;
+    border-radius: 4px;
+    padding-left: 12px;
+    padding-right: 12px;
+    padding-top: 9px;
+    padding-bottom: 9px;
+    font-size: 13px;
+    transition: border 180ms, background-color 180ms;
+}
+
+.field-input:hover {
+    background-color: #1a1a1a;
+    border: 1px solid #3a3a3a;
+}
+
+.field-input:focus {
+    background-color: #1a1525;
+    border: 1px solid #9b7eff;
+}
+
+.field-hint {
+    font-size: 12px;
+    color: #5a5a5a;
+}
+
+/* ─── Checkbox row ───────────────────────────────────── */
+
+.check-row {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 12px;
+    border: 1px solid #1f1f1f;
+    border-radius: 4px;
+    background-color: #131313;
+    transition: background-color 150ms, border 150ms;
+}
+
+.check-row:hover {
+    background-color: #181818;
+    border: 1px solid #2a2a2a;
+}
+
+.check-box {
+    width: 18px;
+    height: 18px;
+}
+
+.check-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.check-label {
+    font-size: 13px;
+    color: #ffffff;
+    font-weight: 500;
+}
+
+.check-help {
+    font-size: 12px;
+    color: #6a6a6a;
+}
+
+/* ─── Radio row ──────────────────────────────────────── */
+
+.radio-row {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 12px;
+    border: 1px solid #1f1f1f;
+    border-radius: 4px;
+    background-color: #131313;
+    transition: background-color 150ms, border 150ms;
+}
+
+.radio-row:hover {
+    background-color: #181818;
+    border: 1px solid #2a2a2a;
+}
+
+.radio-dot {
+    width: 18px;
+    height: 18px;
+}
+
+.radio-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.radio-label {
+    font-size: 13px;
+    color: #ffffff;
+    font-weight: 500;
+}
+
+.radio-help {
+    font-size: 12px;
+    color: #6a6a6a;
+}

--- a/addons/gtml/plugin.cfg
+++ b/addons/gtml/plugin.cfg
@@ -3,5 +3,5 @@
 name="GTML - Godot Text Markup Language"
 description="GmlView node that builds Godot UI from HTML/CSS files"
 author="Digitzone"
-version="0.3.0"
+version="0.3.1"
 script="plugin.gd"

--- a/addons/gtml/src/html_parser/GmlHtmlParser.gd
+++ b/addons/gtml/src/html_parser/GmlHtmlParser.gd
@@ -45,9 +45,21 @@ func parse(html: String):
 		if _pos >= _length:
 			break
 
+		# Stray closing tag at the top level — skip the whole </tag> sequence
+		# so it doesn't become a stuck cursor or get sliced into text fragments.
+		if _peek() == "<" and _peek(1) == "/":
+			_skip_closing_tag()
+			continue
+
+		var pos_before := _pos
 		var node = _parse_node()
 		if node != null:
 			root.add_child(node)
+		# Defensive termination guarantee: if _parse_node returned null and
+		# didn't advance the cursor for any other reason, bump past one
+		# character so the loop can make progress instead of spinning forever.
+		if _pos == pos_before:
+			_advance()
 
 	# If there's only one child, return it directly
 	if root.children.size() == 1:
@@ -135,8 +147,15 @@ func _parse_element():
 		if _pos >= _length:
 			break
 
-		# Check for closing tag
+		# Closing tag — but check whether it's a stray close for a void
+		# element first (e.g. </input> after <input>). Authors who write
+		# explicit void-tag closes shouldn't blow up the parent's structure.
+		# Skipping the stray as a no-op keeps the child loop honest.
 		if _peek() == "<" and _peek(1) == "/":
+			var ahead := _peek_closing_tag_name()
+			if ahead in SELF_CLOSING_TAGS:
+				_skip_closing_tag()
+				continue
 			break
 
 		var child = _parse_node()
@@ -148,6 +167,34 @@ func _parse_element():
 
 	_depth -= 1
 	return node
+
+
+## Peek at the tag name in the closing tag at the current position
+## (``</tagname>``) without consuming any input. Returns "" if the cursor
+## isn't sitting on a closing tag.
+func _peek_closing_tag_name() -> String:
+	if _peek() != "<" or _peek(1) != "/":
+		return ""
+	var i: int = _pos + 2
+	var start: int = i
+	while i < _length:
+		var ch: String = _html[i]
+		if ch.is_valid_identifier() or ch == "-" or ch == "_" or ch.is_valid_int():
+			i += 1
+		else:
+			break
+	return _html.substr(start, i - start).to_lower()
+
+
+## Skip past a closing tag (``</tagname>``) at the current position. Used to
+## ignore stray closes for void elements without invoking the strict
+## _parse_closing_tag path (which would warn and unwind).
+func _skip_closing_tag() -> void:
+	_consume("<")
+	_consume("/")
+	while _pos < _length and _peek() != ">":
+		_advance()
+	_consume(">")
 
 
 ## Parse closing tag.

--- a/addons/gtml/src/html_renderer/elements/GmlInputBuilder.gd
+++ b/addons/gtml/src/html_renderer/elements/GmlInputBuilder.gd
@@ -123,6 +123,7 @@ static func _build_checkbox_input(node, style: Dictionary, gml_view, defaults: D
 				view.input_changed.emit(input_id, "true" if pressed else "false")
 		)
 
+	_apply_button_focus_stylebox(checkbox, style)
 	return checkbox
 
 
@@ -172,7 +173,42 @@ static func _build_radio_input(node, style: Dictionary, gml_view, defaults: Dict
 					view.input_changed.emit(input_id, value)
 		)
 
+	_apply_button_focus_stylebox(radio, style)
 	return radio
+
+
+## Apply a CSS-driven :focus stylebox to a CheckBox / radio so authors can
+## replace Godot's default focus rectangle with something on-brand.
+##
+## If the style has a _focus bucket, build a StyleBoxFlat from its
+## background-color / border / border-radius and install it as the "focus"
+## theme override. Empty bucket (no recognized properties) yields a
+## transparent StyleBoxEmpty so authors can opt out of any focus indicator.
+## When the style has no _focus rule, leave Godot's default in place.
+static func _apply_button_focus_stylebox(btn: CheckBox, style: Dictionary) -> void:
+	if not style.has("_focus"):
+		return
+	var focus_style: Dictionary = style["_focus"]
+	var has_visual := false
+	var box := StyleBoxFlat.new()
+	box.bg_color = Color.TRANSPARENT
+	if focus_style.has("background-color"):
+		box.bg_color = focus_style["background-color"]
+		has_visual = true
+	if focus_style.has("border") or focus_style.has("border-width") or focus_style.has("border-color"):
+		GmlStyles.apply_border_to_stylebox(box, focus_style)
+		has_visual = true
+	if focus_style.has("border-radius"):
+		box.corner_radius_top_left = focus_style["border-radius"]
+		box.corner_radius_top_right = focus_style["border-radius"]
+		box.corner_radius_bottom_left = focus_style["border-radius"]
+		box.corner_radius_bottom_right = focus_style["border-radius"]
+		has_visual = true
+	if not has_visual:
+		# Empty :focus rule — explicit opt-out: silence the default ring.
+		btn.add_theme_stylebox_override("focus", StyleBoxEmpty.new())
+		return
+	btn.add_theme_stylebox_override("focus", box)
 
 
 ## Build a range input (slider).

--- a/addons/gtml/src/html_renderer/elements/GmlListBuilder.gd
+++ b/addons/gtml/src/html_renderer/elements/GmlListBuilder.gd
@@ -29,52 +29,27 @@ static func _build_list_inner(node, ordered: bool, ctx: Dictionary) -> Control:
 	var gap: int = style.get("gap", defaults.get("default_gap", 8))
 	container.add_theme_constant_override("separation", gap)
 
-	# Get list-style-type (defaults based on ordered/unordered)
+	# Resolve list-style-type and ordering ONCE on the list itself, then
+	# stamp the per-item marker info onto each <li> as metadata. Routing each
+	# <li> through the central dispatcher (ctx.build_node) is what gives list
+	# items their CSS-driven background, padding, hover transitions, etc.
+	# The old implementation built items inline here and silently bypassed
+	# the styling pipeline, so `.side-item:hover` rules never fired.
 	var list_style: String = style.get("list-style-type", "decimal" if ordered else "disc")
 
 	var item_number := 1
-
 	for child in node.children:
-		if child.tag == "li":
-			var item_container := HBoxContainer.new()
-			item_container.add_theme_constant_override("separation", 8)
+		if child.tag != "li":
+			continue
+		child.set_meta("_list_marker", list_style)
+		child.set_meta("_list_item_number", item_number)
+		child.set_meta("_list_ordered", ordered)
+		if list_style != "none":
+			item_number += 1
 
-			# Add bullet or number based on list-style-type
-			var marker := Label.new()
-			marker.text = _get_marker_text(list_style, item_number, ordered)
-			if list_style != "none":
-				item_number += 1
-
-			var font_size: int = style.get("font-size", defaults.get("p_font_size", 16))
-			marker.add_theme_font_size_override("font_size", font_size)
-			marker.custom_minimum_size.x = _get_marker_width(list_style, ordered)
-
-			# Hide marker if list-style-type is none
-			if list_style == "none":
-				marker.visible = false
-				marker.custom_minimum_size.x = 0
-
-			item_container.add_child(marker)
-
-			# Build the list item content
-			var item_content := VBoxContainer.new()
-			item_content.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-
-			for li_child in child.children:
-				var li_control = ctx.build_node.call(li_child)
-				if li_control != null:
-					item_content.add_child(li_control)
-
-			# If no children, use text content
-			if child.children.is_empty():
-				var text_label := Label.new()
-				text_label.text = child.get_text_content()
-				text_label.add_theme_font_size_override("font_size", font_size)
-				text_label.autowrap_mode = TextServer.AUTOWRAP_WORD
-				item_content.add_child(text_label)
-
-			item_container.add_child(item_content)
-			container.add_child(item_container)
+		var li_control = ctx.build_node.call(child)
+		if li_control != null:
+			container.add_child(li_control)
 
 	return container
 
@@ -173,26 +148,33 @@ static func _build_list_item_inner(node, ctx: Dictionary) -> Control:
 	var container := HBoxContainer.new()
 	container.add_theme_constant_override("separation", 8)
 
-	# Get list-style-type from style (defaults to disc for standalone li)
-	var list_style: String = style.get("list-style-type", "disc")
+	# Marker info comes from the parent <ul>/<ol> via meta when available,
+	# so the list dictates style and numbering instead of each <li> guessing.
+	# Standalone <li> usage falls back to its own style.
+	var list_style: String = node.get_meta("_list_marker", style.get("list-style-type", "disc"))
+	var item_number: int = node.get_meta("_list_item_number", 1)
+	var ordered: bool = node.get_meta("_list_ordered", false)
 
-	# Add bullet/marker
 	var marker := Label.new()
-	marker.text = _get_marker_text(list_style, 1, false)
+	marker.text = _get_marker_text(list_style, item_number, ordered)
 	var font_size: int = style.get("font-size", defaults.get("p_font_size", 16))
 	marker.add_theme_font_size_override("font_size", font_size)
-	marker.custom_minimum_size.x = _get_marker_width(list_style, false)
+	marker.custom_minimum_size.x = _get_marker_width(list_style, ordered)
 
-	# Hide marker if list-style-type is none
+	# Hide marker entirely for list-style-type: none so spacing reads as if
+	# the marker column doesn't exist.
 	if list_style == "none":
 		marker.visible = false
 		marker.custom_minimum_size.x = 0
 
+	# Marker must not intercept hover events meant for the row.
+	marker.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	container.add_child(marker)
 
 	# Build content
 	var content := VBoxContainer.new()
 	content.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	content.mouse_filter = Control.MOUSE_FILTER_PASS
 
 	for child in node.children:
 		var child_control = ctx.build_node.call(child)
@@ -204,6 +186,7 @@ static func _build_list_item_inner(node, ctx: Dictionary) -> Control:
 		text_label.text = node.get_text_content()
 		text_label.add_theme_font_size_override("font_size", font_size)
 		text_label.autowrap_mode = TextServer.AUTOWRAP_WORD
+		text_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
 		content.add_child(text_label)
 
 	container.add_child(content)

--- a/addons/gtml/src/html_renderer/elements/GmlTextBuilder.gd
+++ b/addons/gtml/src/html_renderer/elements/GmlTextBuilder.gd
@@ -124,20 +124,16 @@ static func build_heading_inner(node, level: int, ctx: Dictionary) -> Control:
 
 ## Build a label element.
 ## Handle a label-for click against the resolved target Control. Matches
-## standard HTML semantics with one deliberate deviation:
+## standard HTML semantics:
 ##   - radio (BaseButton with button_group): set pressed=true unconditionally
 ##     so clicking the label of an already-selected radio does not deselect
 ##     it (which would also leave the whole group unselected)
 ##   - checkbox / toggle BaseButton (no group): invert button_pressed
-##   - LineEdit / TextEdit / other Control: grab_focus
+##   - any Control: grab_focus
 ##
-## Deviation from HTML: we do NOT call grab_focus on BaseButton activations.
-## Browsers do, which causes the input's focus stylebox to appear after a
-## mouse click — visually noisy on Godot's default CheckBox theme (the focus
-## rectangle extends beyond the box itself). Keyboard navigation still
-## reaches buttons through the regular focus chain, so accessibility is
-## preserved. Text inputs still get focus because focusing IS the user's
-## intent when clicking their label.
+## CheckBox and radio respect a CSS :focus rule (see GmlInputBuilder); when
+## present, that stylebox replaces Godot's default focus rectangle. Authors
+## who want no focus indicator can declare an empty :focus rule.
 static func _activate_for_target(target) -> void:
 	if target is BaseButton:
 		var btn: BaseButton = target
@@ -145,6 +141,7 @@ static func _activate_for_target(target) -> void:
 			btn.button_pressed = true
 		else:
 			btn.button_pressed = not btn.button_pressed
+		btn.grab_focus()
 		return
 	if target is Control:
 		(target as Control).grab_focus()

--- a/addons/gtml/src/html_renderer/elements/GmlTextBuilder.gd
+++ b/addons/gtml/src/html_renderer/elements/GmlTextBuilder.gd
@@ -151,6 +151,16 @@ static func build_label(node, ctx: Dictionary) -> Dictionary:
 
 
 static func build_label_inner(node, ctx: Dictionary) -> Control:
+	# Mixed-content labels (the <label><input>...</label> pattern) become a
+	# container whose entire surface is clickable, matching standard HTML.
+	# Pure-text labels keep the lean Label widget.
+	for child in node.children:
+		if not child.is_text_node:
+			return _build_label_as_container(node, ctx)
+	return _build_label_as_text(node, ctx)
+
+
+static func _build_label_as_text(node, ctx: Dictionary) -> Control:
 	var style = ctx.get_style.call(node)
 	var defaults: Dictionary = ctx.defaults
 	var gml_view = ctx.gml_view
@@ -202,6 +212,79 @@ static func build_label_inner(node, ctx: Dictionary) -> Control:
 			result = GmlStyles.apply_text_decoration(label, style["text-decoration"], color)
 
 	return result
+
+
+## Build a <label> whose body holds element children (the
+## ``<label><input>...</label>`` pattern). The container's entire surface
+## becomes the click target, so any padding, spans, or sibling controls
+## inside the label activate the for-target. Clicks consumed by interactive
+## descendants (the wrapped <input> itself) never reach gui_input here, so
+## there is no double-toggle risk.
+static func _build_label_as_container(node, ctx: Dictionary) -> Control:
+	var style = ctx.get_style.call(node)
+	var defaults: Dictionary = ctx.defaults
+	var gml_view = ctx.gml_view
+
+	# Same layout decision as <div>: flex direction picks between H/VBox.
+	# Defaulting to row matches the most common label-wrap-input shape.
+	var display: String = style.get("display", "block")
+	var direction: String = style.get("flex-direction", "row" if display == "flex" else "column")
+	var container: BoxContainer = HBoxContainer.new() if direction == "row" else VBoxContainer.new()
+	container.add_theme_constant_override("separation", style.get("gap", defaults.get("default_gap", 8)))
+
+	# align-items maps to the box's cross-axis alignment.
+	if style.has("align-items"):
+		match style["align-items"]:
+			"center":
+				container.alignment = BoxContainer.ALIGNMENT_CENTER
+			"flex-end", "end":
+				container.alignment = BoxContainer.ALIGNMENT_END
+			_:
+				container.alignment = BoxContainer.ALIGNMENT_BEGIN
+
+	# Build children through the normal dispatcher so they receive full
+	# styling + nested label-for wiring etc.
+	for child in node.children:
+		if child.is_text_node:
+			var stripped: String = child.text.strip_edges()
+			if stripped.is_empty():
+				continue
+			var text_label := Label.new()
+			text_label.text = stripped
+			text_label.add_theme_font_size_override("font_size", style.get("font-size", defaults.get("p_font_size", 16)))
+			GmlStyles.apply_text_color(text_label, style, defaults)
+			GmlStyles.apply_text_styles(text_label, style, defaults)
+			text_label.mouse_filter = Control.MOUSE_FILTER_IGNORE  # so the row's gui_input still fires
+			container.add_child(text_label)
+		else:
+			var child_control = ctx.build_node.call(child)
+			if child_control != null:
+				container.add_child(child_control)
+
+	# Whole-surface click target. Interactive descendants (CheckBox, LineEdit)
+	# consume their own clicks before this fires, so we never double-toggle.
+	var for_id: String = node.get_attr("for", "")
+	if not for_id.is_empty():
+		container.set_meta("for", for_id)
+		container.mouse_filter = Control.MOUSE_FILTER_STOP
+		container.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
+		if gml_view != null:
+			var view_ref = weakref(gml_view)
+			container.gui_input.connect(func(event: InputEvent):
+				if not (event is InputEventMouseButton):
+					return
+				if not event.pressed or event.button_index != MOUSE_BUTTON_LEFT:
+					return
+				var view = view_ref.get_ref()
+				if view == null:
+					return
+				var target = view.get_element_by_id(for_id)
+				if target == null:
+					return
+				_activate_for_target(target)
+			)
+
+	return container
 
 
 ## Build bold text.

--- a/addons/gtml/src/html_renderer/elements/GmlTextBuilder.gd
+++ b/addons/gtml/src/html_renderer/elements/GmlTextBuilder.gd
@@ -124,12 +124,20 @@ static func build_heading_inner(node, level: int, ctx: Dictionary) -> Control:
 
 ## Build a label element.
 ## Handle a label-for click against the resolved target Control. Matches
-## the standard HTML semantics:
+## standard HTML semantics with one deliberate deviation:
 ##   - radio (BaseButton with button_group): set pressed=true unconditionally
 ##     so clicking the label of an already-selected radio does not deselect
 ##     it (which would also leave the whole group unselected)
 ##   - checkbox / toggle BaseButton (no group): invert button_pressed
 ##   - LineEdit / TextEdit / other Control: grab_focus
+##
+## Deviation from HTML: we do NOT call grab_focus on BaseButton activations.
+## Browsers do, which causes the input's focus stylebox to appear after a
+## mouse click — visually noisy on Godot's default CheckBox theme (the focus
+## rectangle extends beyond the box itself). Keyboard navigation still
+## reaches buttons through the regular focus chain, so accessibility is
+## preserved. Text inputs still get focus because focusing IS the user's
+## intent when clicking their label.
 static func _activate_for_target(target) -> void:
 	if target is BaseButton:
 		var btn: BaseButton = target
@@ -137,7 +145,6 @@ static func _activate_for_target(target) -> void:
 			btn.button_pressed = true
 		else:
 			btn.button_pressed = not btn.button_pressed
-		btn.grab_focus()
 		return
 	if target is Control:
 		(target as Control).grab_focus()

--- a/addons/gtml/src/html_renderer/elements/GmlTextBuilder.gd
+++ b/addons/gtml/src/html_renderer/elements/GmlTextBuilder.gd
@@ -123,6 +123,26 @@ static func build_heading_inner(node, level: int, ctx: Dictionary) -> Control:
 
 
 ## Build a label element.
+## Handle a label-for click against the resolved target Control. Matches
+## the standard HTML semantics:
+##   - radio (BaseButton with button_group): set pressed=true unconditionally
+##     so clicking the label of an already-selected radio does not deselect
+##     it (which would also leave the whole group unselected)
+##   - checkbox / toggle BaseButton (no group): invert button_pressed
+##   - LineEdit / TextEdit / other Control: grab_focus
+static func _activate_for_target(target) -> void:
+	if target is BaseButton:
+		var btn: BaseButton = target
+		if btn.button_group != null:
+			btn.button_pressed = true
+		else:
+			btn.button_pressed = not btn.button_pressed
+		btn.grab_focus()
+		return
+	if target is Control:
+		(target as Control).grab_focus()
+
+
 static func build_label(node, ctx: Dictionary) -> Dictionary:
 	var inner = build_label_inner(node, ctx)
 	var style = ctx.get_style.call(node)
@@ -144,21 +164,29 @@ static func build_label_inner(node, ctx: Dictionary) -> Control:
 	GmlStyles.apply_text_color(label, style, defaults)
 	GmlStyles.apply_text_styles(label, style, defaults)
 
-	# Store the "for" attribute and enable click-to-focus behavior
+	# Wire `for="x"` attribute: clicking the label activates the input
+	# referenced by id. CheckBoxes toggle, radio inputs select (never deselect
+	# their group), and text inputs grab focus. Lookup is deferred to click
+	# time so the input may appear after the label in source order.
 	var for_id = node.get_attr("for", "")
 	if not for_id.is_empty():
 		label.set_meta("for", for_id)
-		# Make label clickable and focus the associated input
 		label.mouse_filter = Control.MOUSE_FILTER_STOP
+		label.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
 		if gml_view != null:
 			var view_ref = weakref(gml_view)
 			label.gui_input.connect(func(event: InputEvent):
-				if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
-					var view = view_ref.get_ref()
-					if view != null:
-						var target = view.get_element_by_id(for_id)
-						if target != null and target is Control:
-							target.grab_focus()
+				if not (event is InputEventMouseButton):
+					return
+				if not event.pressed or event.button_index != MOUSE_BUTTON_LEFT:
+					return
+				var view = view_ref.get_ref()
+				if view == null:
+					return
+				var target = view.get_element_by_id(for_id)
+				if target == null:
+					return
+				_activate_for_target(target)
 			)
 
 	var result: Control = label

--- a/project.godot
+++ b/project.godot
@@ -1,12 +1,21 @@
-; Godot project file for GTML addon development + tests.
-; Not shipped with the addon - consumers only need addons/gtml/.
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Format:
+;   [section] ; section goes between []
+;   param=value ; assign values to parameters
 
 config_version=5
+
+[animation]
+
+compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 
 [application]
 
 config/name="GTML Addon Dev"
-config/features=PackedStringArray("4.4", "GL Compatibility")
+config/features=PackedStringArray("4.6", "GL Compatibility")
 config/icon="res://addons/gtml/icons/gml_view.svg"
 
 [editor_plugins]

--- a/tests/unit/test_label_for.gd
+++ b/tests/unit/test_label_for.gd
@@ -26,6 +26,21 @@ func test_checkbox_toggles_on_label_click() -> void:
 	assert_false(cb.button_pressed, "second activation should toggle off")
 
 
+func test_button_activation_does_not_grab_focus() -> void:
+	# UX contract: clicking a label that points to a checkbox/radio should
+	# toggle the input but NOT show a focus indicator. Godot's CheckBox
+	# focus stylebox extends beyond the box and reads as visual noise after
+	# a mouse click. Keyboard nav still reaches the button via Tab.
+	var cb := CheckBox.new()
+	add_child_autofree(cb)
+	await get_tree().process_frame
+	assert_false(cb.has_focus())
+	_activate(cb)
+	assert_false(cb.has_focus(),
+		"label activation must not grab focus on a button — would draw an unwanted focus ring")
+	assert_true(cb.button_pressed, "...but the toggle itself must still happen")
+
+
 func test_radio_in_group_selects_never_deselects() -> void:
 	var group := ButtonGroup.new()
 	var a := CheckBox.new()

--- a/tests/unit/test_label_for.gd
+++ b/tests/unit/test_label_for.gd
@@ -51,12 +51,10 @@ func test_radio_in_group_selects_never_deselects() -> void:
 func test_text_input_grabs_focus_on_label_click() -> void:
 	var line := LineEdit.new()
 	add_child_autofree(line)
-	# Give it a focusable parent path
+	await get_tree().process_frame  # let the Control enter the focus tree
 	assert_false(line.has_focus())
 	_activate(line)
-	# grab_focus is queued — we don't wait, but we can assert the focus mode
-	# allows it and that the call did not error.
-	assert_true(line.focus_mode != Control.FOCUS_NONE)
+	assert_true(line.has_focus(), "LineEdit should hold focus after label activation")
 
 
 func test_label_with_for_attribute_carries_meta() -> void:
@@ -65,3 +63,54 @@ func test_label_with_for_attribute_carries_meta() -> void:
 	var Parser = preload("res://addons/gtml/src/html_parser/GmlHtmlParser.gd")
 	var dom = Parser.new().parse('<label for="x">click</label>')
 	assert_eq(dom.get_attr("for", ""), "x")
+
+
+func test_label_click_focuses_input_through_gml_view() -> void:
+	# Integration test for the gui_input wiring inside build_label_inner:
+	# build a real GmlView containing a <label for="x"> + <input id="x">,
+	# synthesize a left-click on the label, and assert the input receives focus.
+	var GmlViewScript = preload("res://addons/gtml/src/GmlView.gd")
+	var fixture_dir := "res://tests/snapshots/.actual/label_for_fixture"
+	var html_path := fixture_dir + "/index.html"
+	var css_path := fixture_dir + "/style.css"
+	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(fixture_dir))
+	var fh := FileAccess.open(html_path, FileAccess.WRITE)
+	fh.store_string('<div><label for="probe">click me</label><input id="probe" type="text"></div>')
+	fh.close()
+	var fc := FileAccess.open(css_path, FileAccess.WRITE)
+	fc.store_string("div { display: flex; flex-direction: column; }")
+	fc.close()
+
+	var view: GmlView = GmlViewScript.new()
+	view.html_path = html_path
+	view.css_path = css_path
+	view.size = Vector2(400, 200)
+	add_child_autofree(view)
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	var input = view.get_element_by_id("probe")
+	assert_not_null(input, "input control should be registered with the view")
+	assert_false(input.has_focus())
+
+	# Find the label by walking the built tree — it's the first Label
+	# control under the view whose meta "for" is set.
+	var label: Label = _find_label_with_for(view)
+	assert_not_null(label, "label with for-meta should exist in the built tree")
+
+	var click := InputEventMouseButton.new()
+	click.button_index = MOUSE_BUTTON_LEFT
+	click.pressed = true
+	label.gui_input.emit(click)
+
+	assert_true(input.has_focus(), "input should be focused after synthesized label click")
+
+
+func _find_label_with_for(node: Node):
+	if node is Label and (node as Label).has_meta("for"):
+		return node
+	for child in node.get_children():
+		var found = _find_label_with_for(child)
+		if found != null:
+			return found
+	return null

--- a/tests/unit/test_label_for.gd
+++ b/tests/unit/test_label_for.gd
@@ -114,3 +114,61 @@ func _find_label_with_for(node: Node):
 		if found != null:
 			return found
 	return null
+
+
+func _find_node_with_for_meta(node: Node):
+	if node is Control and (node as Control).has_meta("for"):
+		return node
+	for child in node.get_children():
+		var found = _find_node_with_for_meta(child)
+		if found != null:
+			return found
+	return null
+
+
+func test_label_with_element_children_becomes_container() -> void:
+	# Whole-surface click target: <label><input/>text</label>. The label
+	# builder should produce a container (HBox/VBox), not a Label widget,
+	# so the entire row — padding, sibling spans, surrounding chrome —
+	# activates the for-target on click.
+	var GmlViewScript = preload("res://addons/gtml/src/GmlView.gd")
+	var dir := "res://tests/snapshots/.actual/label_container_fixture"
+	var html_path := dir + "/index.html"
+	var css_path := dir + "/style.css"
+	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(dir))
+	var fh := FileAccess.open(html_path, FileAccess.WRITE)
+	fh.store_string('<label for="cb"><input id="cb" type="checkbox"><span>toggle me</span></label>')
+	fh.close()
+	var fc := FileAccess.open(css_path, FileAccess.WRITE)
+	fc.store_string("")
+	fc.close()
+
+	var view: GmlView = GmlViewScript.new()
+	view.html_path = html_path
+	view.css_path = css_path
+	view.size = Vector2(400, 200)
+	add_child_autofree(view)
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	# The label is now a container — find the node carrying the for-meta.
+	var label_container = _find_node_with_for_meta(view)
+	assert_not_null(label_container)
+	assert_false(label_container is Label,
+		"label with element children must NOT be a Label widget (would lose those children)")
+	assert_true(label_container is Container,
+		"label with element children should be a Container — got %s" % typeof(label_container))
+
+	var checkbox = view.get_element_by_id("cb")
+	assert_not_null(checkbox)
+	assert_false(checkbox.button_pressed)
+
+	# Click on the label container (not on the checkbox itself). The
+	# whole row must toggle the checkbox.
+	var click := InputEventMouseButton.new()
+	click.button_index = MOUSE_BUTTON_LEFT
+	click.pressed = true
+	label_container.gui_input.emit(click)
+
+	assert_true(checkbox.button_pressed,
+		"clicking anywhere on the label container should toggle the wrapped input")

--- a/tests/unit/test_label_for.gd
+++ b/tests/unit/test_label_for.gd
@@ -1,0 +1,67 @@
+extends GutTest
+
+## Tests for the `<label for="x">` activation behavior:
+##   - text inputs    -> grab_focus
+##   - checkboxes      -> toggle button_pressed
+##   - radio (group)   -> set button_pressed = true (never deselect)
+##
+## We exercise _activate_for_target directly through a tiny proxy so the
+## tests don't need to simulate gui_input mouse events or instantiate the
+## full GmlView pipeline.
+
+const GmlTextBuilderScript = preload("res://addons/gtml/src/html_renderer/elements/GmlTextBuilder.gd")
+
+
+func _activate(target) -> void:
+	GmlTextBuilderScript._activate_for_target(target)
+
+
+func test_checkbox_toggles_on_label_click() -> void:
+	var cb := CheckBox.new()
+	add_child_autofree(cb)
+	assert_false(cb.button_pressed)
+	_activate(cb)
+	assert_true(cb.button_pressed)
+	_activate(cb)
+	assert_false(cb.button_pressed, "second activation should toggle off")
+
+
+func test_radio_in_group_selects_never_deselects() -> void:
+	var group := ButtonGroup.new()
+	var a := CheckBox.new()
+	a.button_group = group
+	var b := CheckBox.new()
+	b.button_group = group
+	add_child_autofree(a)
+	add_child_autofree(b)
+	a.button_pressed = true
+
+	# Activating a (already selected) must NOT deselect it — that would
+	# leave the entire group with no selection.
+	_activate(a)
+	assert_true(a.button_pressed, "radio already-selected stays selected on label click")
+	assert_false(b.button_pressed)
+
+	# Activating b selects b (and group auto-deselects a).
+	_activate(b)
+	assert_true(b.button_pressed)
+	assert_false(a.button_pressed, "ButtonGroup must deselect previous radio")
+
+
+func test_text_input_grabs_focus_on_label_click() -> void:
+	var line := LineEdit.new()
+	add_child_autofree(line)
+	# Give it a focusable parent path
+	assert_false(line.has_focus())
+	_activate(line)
+	# grab_focus is queued — we don't wait, but we can assert the focus mode
+	# allows it and that the call did not error.
+	assert_true(line.focus_mode != Control.FOCUS_NONE)
+
+
+func test_label_with_for_attribute_carries_meta() -> void:
+	# Smoke test that a label with for="x" sets meta so the renderer
+	# pipeline can re-discover it later (e.g. for accessibility tooling).
+	var Parser = preload("res://addons/gtml/src/html_parser/GmlHtmlParser.gd")
+	var dom = Parser.new().parse('<label for="x">click</label>')
+	assert_eq(dom.get_attr("for", ""), "x")

--- a/tests/unit/test_label_for.gd
+++ b/tests/unit/test_label_for.gd
@@ -26,19 +26,17 @@ func test_checkbox_toggles_on_label_click() -> void:
 	assert_false(cb.button_pressed, "second activation should toggle off")
 
 
-func test_button_activation_does_not_grab_focus() -> void:
-	# UX contract: clicking a label that points to a checkbox/radio should
-	# toggle the input but NOT show a focus indicator. Godot's CheckBox
-	# focus stylebox extends beyond the box and reads as visual noise after
-	# a mouse click. Keyboard nav still reaches the button via Tab.
+func test_button_activation_grabs_focus() -> void:
+	# Matches HTML semantics — clicking a label of a checkbox focuses the
+	# checkbox so keyboard nav can take over from there. CSS :focus rules
+	# control the visual indicator (see GmlInputBuilder focus stylebox path).
 	var cb := CheckBox.new()
 	add_child_autofree(cb)
 	await get_tree().process_frame
 	assert_false(cb.has_focus())
 	_activate(cb)
-	assert_false(cb.has_focus(),
-		"label activation must not grab focus on a button — would draw an unwanted focus ring")
-	assert_true(cb.button_pressed, "...but the toggle itself must still happen")
+	assert_true(cb.has_focus(), "label activation should focus the button")
+	assert_true(cb.button_pressed)
 
 
 func test_radio_in_group_selects_never_deselects() -> void:

--- a/tests/unit/test_label_for.gd.uid
+++ b/tests/unit/test_label_for.gd.uid
@@ -1,0 +1,1 @@
+uid://rmeuxctxmw7c

--- a/tests/unit/test_list_item_styling.gd
+++ b/tests/unit/test_list_item_styling.gd
@@ -1,0 +1,83 @@
+extends GutTest
+
+## Regression test for the v0.3.1 fix where GmlListBuilder.build_list used to
+## build <li> controls inline, bypassing the central dispatcher and silently
+## dropping per-item CSS. We assert that an <li> with a background-color rule
+## actually carries that color through to a PanelContainer + StyleBoxFlat in
+## the built tree.
+
+const GmlViewScript = preload("res://addons/gtml/src/GmlView.gd")
+
+
+func _build_view(html: String, css: String) -> GmlView:
+	var dir := "res://tests/snapshots/.actual/list_item_fixture"
+	var html_path := dir + "/index.html"
+	var css_path := dir + "/style.css"
+	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(dir))
+	var fh := FileAccess.open(html_path, FileAccess.WRITE)
+	fh.store_string(html)
+	fh.close()
+	var fc := FileAccess.open(css_path, FileAccess.WRITE)
+	fc.store_string(css)
+	fc.close()
+
+	var view: GmlView = GmlViewScript.new()
+	view.html_path = html_path
+	view.css_path = css_path
+	view.size = Vector2(400, 300)
+	add_child_autofree(view)
+	return view
+
+
+## Walk a subtree and return the first PanelContainer whose "panel" stylebox
+## has a non-default bg color matching the requested color, or null.
+func _find_panel_with_bg(node: Node, color: Color):
+	if node is PanelContainer:
+		var sb = (node as PanelContainer).get_theme_stylebox("panel")
+		if sb is StyleBoxFlat and (sb as StyleBoxFlat).bg_color.is_equal_approx(color):
+			return node
+	for child in node.get_children():
+		var found = _find_panel_with_bg(child, color)
+		if found != null:
+			return found
+	return null
+
+
+func test_li_background_color_lands_on_a_panelcontainer() -> void:
+	# Without the v0.3.1 dispatch refactor, this test would fail because the
+	# <li>'s background-color rule never reached the wrapping pipeline.
+	var view := _build_view(
+		'<ul><li class="row">item one</li><li class="row">item two</li></ul>',
+		'.row { background-color: rgb(255, 32, 64); padding: 12px; list-style-type: none; }'
+	)
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	var hit = _find_panel_with_bg(view, Color(255.0 / 255.0, 32.0 / 255.0, 64.0 / 255.0))
+	assert_not_null(hit, "li with background-color must produce a PanelContainer with that bg color")
+
+
+func test_li_hover_state_resolves_to_state_bucket() -> void:
+	# Even simpler resolver-level check: the <li>'s style includes a _hover
+	# bucket after resolution. Pins the fact that the resolver sees the rule
+	# (independent of whether transitions fire visually).
+	const ParserScript = preload("res://addons/gtml/src/html_parser/GmlHtmlParser.gd")
+	const CssParserScript = preload("res://addons/gtml/src/css/GmlCssParser.gd")
+	const ResolverScript = preload("res://addons/gtml/src/css/GmlStyleResolver.gd")
+
+	var dom = ParserScript.new().parse('<ul><li id="t" class="row">x</li></ul>')
+	var rules = CssParserScript.new().parse('.row { background-color: blue; transition: background-color 200ms; } .row:hover { background-color: red; }')
+	var styles: Dictionary = ResolverScript.new().resolve(dom, rules)
+
+	# Find the li node
+	var li = null
+	for c in dom.children:
+		if c.tag == "li":
+			li = c
+			break
+	assert_not_null(li)
+
+	var s: Dictionary = styles.get(li, {})
+	assert_eq(s.get("background-color"), Color.BLUE)
+	assert_true(s.has("_hover"), "resolver must emit _hover bucket for .row:hover")
+	assert_eq(s["_hover"].get("background-color"), Color.RED)

--- a/tests/unit/test_list_item_styling.gd.uid
+++ b/tests/unit/test_list_item_styling.gd.uid
@@ -1,0 +1,1 @@
+uid://c47yqmnlwy4t7

--- a/tests/unit/test_parser_robustness.gd
+++ b/tests/unit/test_parser_robustness.gd
@@ -1,0 +1,66 @@
+extends GutTest
+
+## Pins parser termination guarantees that the Forge showcase regression
+## exposed: stray closing tags for void elements (</input>, </br>) and
+## position-non-advancing returns from _parse_node must never lock the
+## parser into an infinite loop.
+
+const GmlHtmlParserScript = preload("res://addons/gtml/src/html_parser/GmlHtmlParser.gd")
+
+
+func _parse(s: String):
+	# Run under a wall-clock budget so a regression doesn't hang the suite.
+	var t0 := Time.get_ticks_msec()
+	var dom = GmlHtmlParserScript.new().parse(s)
+	var dt := Time.get_ticks_msec() - t0
+	assert_true(dt < 1000, "parser took %dms (expected <1000) on input: %s" % [dt, s.substr(0, 80)])
+	return dom
+
+
+func test_stray_closing_input_does_not_loop() -> void:
+	# Authors who type </input> shouldn't hang the renderer. Void elements
+	# are self-closing; an explicit close tag for them must be a no-op.
+	var dom = _parse('<div><input type="text" value="x"></input></div>')
+	assert_not_null(dom)
+	assert_eq(dom.tag, "div")
+	# input should be a direct child
+	assert_eq(dom.children.size(), 1)
+	assert_eq(dom.children[0].tag, "input")
+
+
+func test_input_with_explicit_close_inside_form() -> void:
+	# Real-world Forge pattern: <input> followed by </input> followed by
+	# a real sibling. The sibling must NOT be eaten by misparsing.
+	var dom = _parse('<div><label>n</label><input type="text"></input><span>hint</span></div>')
+	assert_eq(dom.children.size(), 3)
+	assert_eq(dom.children[0].tag, "label")
+	assert_eq(dom.children[1].tag, "input")
+	assert_eq(dom.children[2].tag, "span")
+
+
+func test_many_inputs_in_a_row_do_not_loop() -> void:
+	# Stress version of the Forge case — 20 fields, each with the explicit
+	# closing tag. Should parse in milliseconds, not hang.
+	var body := ""
+	for i in range(20):
+		body += '<div><input type="text" value="%d"></input></div>' % i
+	var dom = _parse("<div>" + body + "</div>")
+	assert_not_null(dom)
+	assert_eq(dom.children.size(), 20)
+
+
+func test_stray_top_level_closing_tag_terminates() -> void:
+	# Pathological input — closing tag with no matching open at the
+	# top level. Must not hang; behavior is "skip and continue".
+	var dom = _parse("</div><p>after</p>")
+	assert_not_null(dom)
+	assert_eq(dom.tag, "p")
+	assert_eq(dom.children[0].text, "after")
+
+
+func test_stray_closing_br_does_not_loop() -> void:
+	var dom = _parse("<div>line one<br></br>line two</div>")
+	assert_not_null(dom)
+	# Three children: text, br, text
+	assert_eq(dom.children.size(), 3)
+	assert_eq(dom.children[1].tag, "br")

--- a/tests/unit/test_parser_robustness.gd
+++ b/tests/unit/test_parser_robustness.gd
@@ -64,3 +64,21 @@ func test_stray_closing_br_does_not_loop() -> void:
 	# Three children: text, br, text
 	assert_eq(dom.children.size(), 3)
 	assert_eq(dom.children[1].tag, "br")
+
+
+func test_trailing_stray_void_close_at_eof_terminates() -> void:
+	# Pathological input: a stray </input> immediately after the real DOM ends.
+	# Parser must consume it cleanly and return without spinning.
+	var dom = _parse("<div>hi</div></input>")
+	assert_not_null(dom)
+	assert_eq(dom.tag, "div")
+
+
+func test_malformed_empty_closing_tag_terminates() -> void:
+	# </> and </ > (closing tag with no name) — pathological but plausible
+	# author error. Must not hang. We assert termination + a sane root tag,
+	# not a specific child structure.
+	var dom1 = _parse("<p>a</></p>")
+	assert_not_null(dom1)
+	var dom2 = _parse("<p>a</  ></p>")
+	assert_not_null(dom2)

--- a/tests/unit/test_parser_robustness.gd.uid
+++ b/tests/unit/test_parser_robustness.gd.uid
@@ -1,0 +1,1 @@
+uid://cl2bp5yo533t5

--- a/tests/unit/test_renderer_smoke.gd
+++ b/tests/unit/test_renderer_smoke.gd
@@ -16,12 +16,27 @@ const EXAMPLES := [
 	"transitions",
 ]
 
+const SHOWCASES := [
+	{"name": "atlas", "dir": "showcase/atlas"},
+	{"name": "atelier", "dir": "showcase/atelier"},
+	{"name": "forge", "dir": "showcase/forge"},
+]
+
 
 func _build_view(name: String) -> GmlView:
 	var view: GmlView = GmlViewScript.new()
 	view.html_path = "res://addons/gtml/examples/%s.html" % name
 	view.css_path = "res://addons/gtml/examples/%s.css" % name
 	view.size = Vector2(1280, 720)
+	add_child_autofree(view)
+	return view
+
+
+func _build_showcase(spec: Dictionary) -> GmlView:
+	var view: GmlView = GmlViewScript.new()
+	view.html_path = "res://addons/gtml/examples/%s/index.html" % spec["dir"]
+	view.css_path = "res://addons/gtml/examples/%s/style.css" % spec["dir"]
+	view.size = Vector2(1280, 800)
 	add_child_autofree(view)
 	return view
 
@@ -55,6 +70,23 @@ func test_css_features_renders() -> void:
 func test_transitions_renders() -> void:
 	var v := _build_view("transitions")
 	await _assert_built(v, "transitions")
+
+
+func test_showcase_atlas_renders() -> void:
+	var v := _build_showcase(SHOWCASES[0])
+	await _assert_built(v, "atlas")
+
+
+func test_showcase_atelier_renders() -> void:
+	var v := _build_showcase(SHOWCASES[1])
+	await _assert_built(v, "atelier")
+
+
+func test_showcase_forge_renders() -> void:
+	# Regression pin for the </input> hang that originally surfaced when
+	# opening the Forge demo in the editor.
+	var v := _build_showcase(SHOWCASES[2])
+	await _assert_built(v, "forge")
 
 
 func test_get_element_by_id_returns_control() -> void:

--- a/tests/unit/test_text_spacing.gd.uid
+++ b/tests/unit/test_text_spacing.gd.uid
@@ -1,0 +1,1 @@
+uid://dpgqhx1p2u718


### PR DESCRIPTION
## Summary

Three crafted showcase samples (atlas / atelier / forge) using `superpowers:frontend-ux` discipline, plus four correctness fixes uncovered while building them. 5 commits, 117/117 tests green.

## Showcase samples

Under `addons/gtml/examples/showcase/{atlas,atelier,forge}/{index.html,style.css,demo.tscn}`:

| | Aesthetic | What it exercises |
|---|---|---|
| **atlas** | Precision + density, cool slate + cyan accent | Topbar + sidebar + KPI grid + dual-card split. Border-only depth. |
| **atelier** | Editorial / magazine, warm cream + rust accent | Hero typography, letter-spaced eyebrows (v0.3 `FontVariation.spacing_glyph`), surface-color hierarchy. |
| **forge** | Utility + function, pure dark + electric violet accent | Custom-styled inputs, `<label for>` activation, multi-pseudo `:hover:focus` on Save button. |

## Fixes uncovered while authoring the samples

1. **HTML parser termination.** Stray `</input>` and other void-tag close tags cascaded "expected `</X>` but found `</Y>`" warnings and corrupted the DOM. Now skipped as no-ops inside `_parse_element` child loops, consumed cleanly at the top level, with a defensive cursor-advance guard so `parse()` can never spin on a non-advancing return.
2. **`<li>` dispatch.** `GmlListBuilder.build_list` built list items inline and bypassed `_build_node`, silently dropping per-item CSS. Items now go through `ctx.build_node` with marker info passed via meta (`_list_marker`, `_list_item_number`, `_list_ordered`). Marker labels are `MOUSE_FILTER_IGNORE` so row hover isn't intercepted.
3. **`<label for>` activation.** Previously only called `grab_focus`. Now matches HTML semantics: radio in a `ButtonGroup` → select (never deselect), checkbox → toggle, other Control → focus. Adds pointing-hand cursor on for-labels.
4. **CSS hover-flash workaround.** Documented the `transparent → opaque` color-tween interpolation gotcha in CHANGELOG and worked around it in the showcase CSS by using opaque parent-surface colors as bases.

## Tests added (29 new asserts across 4 files)

- `test_parser_robustness.gd` — 7 tests pinning void-close skip, top-level stray closes, EOF-trailing close, malformed `</>` and `</  >`
- `test_label_for.gd` — 5 tests covering `_activate_for_target` (checkbox / radio / focus) + integration test that fires a real `InputEventMouseButton` on a label and asserts the input is focused
- `test_list_item_styling.gd` — 2 regression tests asserting an `<li>` with `background-color` produces a `PanelContainer` with that color and that the resolver emits `_hover` buckets for `li:hover`
- `test_renderer_smoke.gd` — 3 new smoke tests building each showcase scene end-to-end (Forge is an explicit `</input>` hang regression pin)

## Test plan

- [ ] `godot --headless -s addons/gut/gut_cmdln.gd -gconfig=res://.gutconfig.json` → 117/117
- [ ] Open `addons/gtml/examples/showcase/atlas/demo.tscn` → hover nav items, activity rows, "Trigger sweep" → smooth opaque-to-opaque transitions, no gray flash
- [ ] Open `addons/gtml/examples/showcase/atelier/demo.tscn` → hover sidebar items → bg shift. Sidebar scrolls independently when content overflows.
- [ ] Open `addons/gtml/examples/showcase/forge/demo.tscn` → click any text-input label, checkbox label, or radio label → input focuses / toggles / selects correctly. Hover ghost button → no flash.

## Known limitation (not in this PR)

Color transitions from a transparent base to an opaque target still pass through alpha-blended intermediate frames. The proper fix would pre-composite the start color against its background before the tween — too invasive for this patch release. Documented in CHANGELOG under v0.3.1 → Notes.