### PR TITLE
v0.4: CSS tokens + transforms + :checked + forms + editor warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,60 @@
 # Changelog
 
+## 0.4.0
+
+### Features
+
+- **CSS custom properties + `var()` + `calc()`** (`GmlCssEval`):
+  - `--name: value` declarations on any selector cascade through descendants
+  - `var(--name)` and `var(--name, fallback)` substitute at compute-style
+    time against the inherited scope; recursive resolution of nested vars
+  - `calc(...)` evaluates flat arithmetic with `+ - * /` and standard
+    precedence. Unit rules: `+`/`-` need matching units, `*`/`/` accept at
+    most one unit-bearing operand. Mixed expressions emit a warning and
+    leave the substring intact.
+- **`:checked` pseudo-class** for CheckBox + radio inputs. Resolver routes
+  to a `_checked` bucket; `GmlInputBuilder` installs the bucket on the
+  CheckBox `pressed` theme stylebox slot (Godot treats `pressed` as the
+  toggle-on visual). Empty `:checked` rule installs `StyleBoxEmpty` for
+  explicit opt-out.
+- **CSS transforms** (`GmlTransformValues`):
+  - `translate(x[, y])` / `translateX` / `translateY` — px values
+  - `scale(s)` / `scale(sx, sy)` / `scaleX` / `scaleY` — unitless
+  - `rotate(45deg | 0.5rad | 0.25turn)` — normalized to radians
+  - Multiple functions compose left-to-right. Pivot defaults to centre
+    (`transform-origin: 50% 50%`).
+- **Form value collection on submit**: `GmlView.get_form_data()` returns
+  `{id|name -> value}` for every registered input — text, textarea,
+  checkbox, slider, select, and the *selected* radio per group keyed by
+  the group's name. Submit buttons now unconditionally emit
+  `form_submitted(get_form_data())` (previously the signal was unused).
+- **`@keydown` attribute** on inputs forwards key-down events to a new
+  `key_pressed(handler: String, event: InputEvent)` signal on `GmlView`.
+  Lets author scripts implement search-as-you-type, autocomplete, hotkeys.
+- **Editor inline parse-warnings overlay**: the GML editor panel grows a
+  PanelContainer that lists every HTML + CSS parser warning after save.
+  Each row is a click-to-jump button that activates the relevant tab and
+  positions the caret at the warning's line + column.
+- **FileSystem-signal hot reload**: in the editor, `GmlView` subscribes
+  to `EditorInterface.get_resource_filesystem().filesystem_changed` and
+  re-checks its files only when the project actually changes. The
+  per-frame `_process` mtime poll stays as a safety net for changes made
+  outside Godot.
+
+### Improvements
+
+- `GmlHtmlParser.get_warnings()` mirrors the CSS parser's contract; every
+  push_warning now carries `{line, col, msg}` for editor tooling.
+
+### Limitations / deferred
+
+- Transforms apply at build time and on resize; they do not yet interpolate
+  through the transition manager. `transform` inside a `:hover` rule will
+  snap instead of animating.
+- `calc()` does not yet handle mixed-unit subtraction (e.g.
+  `calc(100% - 20px)`). Same-unit and unitless arithmetic only.
+
+
 ## 0.3.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,16 @@
   snap instead of animating.
 - `calc()` does not yet handle mixed-unit subtraction (e.g.
   `calc(100% - 20px)`). Same-unit and unitless arithmetic only.
+- Custom-property declarations inside a state bucket (`p:hover { --x: red; }`)
+  are not yet added to the bucket-local scope. The bucket resolves against
+  the base scope only.
+- GTML has no `<form>` scoping: a bare `<input type="submit">` anywhere in
+  the view still fires `form_submitted` with the entire view's input
+  snapshot. Intentional given the embedded-UI use case but worth knowing
+  if multiple forms coexist in one GmlView.
+- Radio inputs without a `name` attribute have no `ButtonGroup` and are
+  silently collected by `get_form_data()` as bools under their `id`
+  (CheckBox semantics). Always set `name=` on radios.
 
 
 ## 0.3.1

--- a/addons/gtml/editor/gml_editor_panel.gd
+++ b/addons/gtml/editor/gml_editor_panel.gd
@@ -6,6 +6,8 @@ extends Control
 
 const HtmlSyntaxHighlighter = preload("res://addons/gtml/editor/html_syntax_highlighter.gd")
 const CssSyntaxHighlighter = preload("res://addons/gtml/editor/css_syntax_highlighter.gd")
+const GmlHtmlParserScript = preload("res://addons/gtml/src/html_parser/GmlHtmlParser.gd")
+const GmlCssParserScript = preload("res://addons/gtml/src/css/GmlCssParser.gd")
 
 #region Node References
 
@@ -51,6 +53,11 @@ var _original_html_content: String = ""
 var _original_css_content: String = ""
 var _html_highlighter: SyntaxHighlighter = null
 var _css_highlighter: SyntaxHighlighter = null
+
+# Inline warning panel built dynamically (so we don't have to touch the .tscn).
+var _warnings_panel: PanelContainer = null
+var _warnings_list: VBoxContainer = null
+var _warnings_header: Label = null
 
 # Editor state preservation (per GmlView node path)
 var _editor_states: Dictionary = {}  # node_path -> { html_caret, html_scroll, css_caret, css_scroll, active_tab }
@@ -519,6 +526,97 @@ func _save_files() -> void:
 		_update_tab_titles()
 		_update_save_button()
 		# GmlView will auto-detect file changes via modification time
+		_refresh_warnings()
+
+#endregion
+
+
+#region Parse warnings panel
+
+## Lazily build a PanelContainer at the bottom of MainContainer holding a
+## VBoxContainer of warning rows. Each warning is a Button that jumps the
+## relevant CodeEdit to the warning's line + column on click.
+func _ensure_warnings_panel() -> void:
+	if _warnings_panel != null and is_instance_valid(_warnings_panel):
+		return
+
+	_warnings_panel = PanelContainer.new()
+	_warnings_panel.name = "WarningsPanel"
+	_warnings_panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_warnings_panel.visible = false
+
+	var inner := VBoxContainer.new()
+	inner.add_theme_constant_override("separation", 2)
+	_warnings_panel.add_child(inner)
+
+	_warnings_header = Label.new()
+	_warnings_header.text = "Parse warnings"
+	_warnings_header.add_theme_color_override("font_color", Color(0.9, 0.7, 0.3))
+	inner.add_child(_warnings_header)
+
+	_warnings_list = VBoxContainer.new()
+	_warnings_list.add_theme_constant_override("separation", 1)
+	inner.add_child(_warnings_list)
+
+	main_container.add_child(_warnings_panel)
+
+
+## Re-parse the current editor buffers, gather warnings from both parsers,
+## and rebuild the inline panel. Called after every save so authors get
+## fast feedback without leaving the editor.
+func _refresh_warnings() -> void:
+	_ensure_warnings_panel()
+
+	# Clear previous rows
+	for child in _warnings_list.get_children():
+		_warnings_list.remove_child(child)
+		child.queue_free()
+
+	var html_warnings: Array = []
+	var css_warnings: Array = []
+
+	if not html_code_edit.text.is_empty():
+		var html_parser = GmlHtmlParserScript.new()
+		html_parser.parse(html_code_edit.text)
+		html_warnings = html_parser.get_warnings()
+
+	if not css_code_edit.text.is_empty():
+		var css_parser = GmlCssParserScript.new()
+		css_parser.parse(css_code_edit.text)
+		css_warnings = css_parser.get_warnings()
+
+	var total: int = html_warnings.size() + css_warnings.size()
+	if total == 0:
+		_warnings_panel.visible = false
+		return
+
+	_warnings_panel.visible = true
+	_warnings_header.text = "Parse warnings (%d)" % total
+
+	for w in html_warnings:
+		_append_warning_row("HTML", w, html_code_edit, html_tab)
+	for w in css_warnings:
+		_append_warning_row("CSS", w, css_code_edit, css_tab)
+
+
+func _append_warning_row(kind: String, w: Dictionary, code_edit: CodeEdit, tab: Control) -> void:
+	var btn := Button.new()
+	btn.text = "[%s %d:%d] %s" % [kind, int(w.get("line", 0)), int(w.get("col", 0)), str(w.get("msg", ""))]
+	btn.alignment = HORIZONTAL_ALIGNMENT_LEFT
+	btn.flat = true
+	btn.add_theme_color_override("font_color", Color(0.85, 0.75, 0.55))
+	btn.pressed.connect(func():
+		# Activate the tab, then jump the caret to the warning's line.
+		var idx := tab_container.get_tab_idx_from_control(tab)
+		if idx >= 0:
+			tab_container.current_tab = idx
+		var line: int = maxi(int(w.get("line", 1)) - 1, 0)
+		var col: int = maxi(int(w.get("col", 1)) - 1, 0)
+		code_edit.set_caret_line(line)
+		code_edit.set_caret_column(col)
+		code_edit.grab_focus()
+	)
+	_warnings_list.add_child(btn)
 
 #endregion
 

--- a/addons/gtml/plugin.cfg
+++ b/addons/gtml/plugin.cfg
@@ -3,5 +3,5 @@
 name="GTML - Godot Text Markup Language"
 description="GmlView node that builds Godot UI from HTML/CSS files"
 author="Digitzone"
-version="0.3.1"
+version="0.4.0"
 script="plugin.gd"

--- a/addons/gtml/src/GmlView.gd
+++ b/addons/gtml/src/GmlView.gd
@@ -105,6 +105,21 @@ func _ready() -> void:
 		# At runtime, wait a frame for size to be set properly before building
 		await get_tree().process_frame
 	_rebuild()
+	_subscribe_to_filesystem_changes()
+
+
+## Hot reload via signal instead of per-frame mtime polling. Editor-only —
+## EditorInterface is not available at runtime. The polling fallback in
+## _process still runs so authors editing files outside Godot (the usual
+## case for HTML/CSS) get picked up even if the editor's filesystem scan
+## hasn't fired yet.
+func _subscribe_to_filesystem_changes() -> void:
+	if not Engine.is_editor_hint() or not auto_reload_in_editor:
+		return
+	var efs = EditorInterface.get_resource_filesystem() if Engine.is_editor_hint() else null
+	if efs != null and efs.has_signal("filesystem_changed"):
+		if not efs.filesystem_changed.is_connected(_check_files_changed):
+			efs.filesystem_changed.connect(_check_files_changed)
 
 
 func _process(_delta: float) -> void:

--- a/addons/gtml/src/GmlView.gd
+++ b/addons/gtml/src/GmlView.gd
@@ -75,6 +75,11 @@ signal selection_changed(select_id: String, value: String)
 ## Contains a dictionary of all input values keyed by id/name.
 signal form_submitted(form_data: Dictionary)
 
+## Emitted when an input with an @keydown handler receives a key press.
+## ``handler`` is the value of the @keydown attribute; ``event`` is the
+## raw InputEventKey so listeners can inspect keycode / modifiers.
+signal key_pressed(handler: String, event: InputEvent)
+
 #endregion
 
 
@@ -402,5 +407,52 @@ func get_radio_group(group_name: String) -> ButtonGroup:
 	if not _radio_groups.has(group_name):
 		_radio_groups[group_name] = ButtonGroup.new()
 	return _radio_groups[group_name]
+
+
+## Collect all registered input values into a single dictionary, keyed by the
+## input's id (or by the radio group's name for radios). Returned types:
+##   - LineEdit / TextEdit -> String
+##   - CheckBox (no group) -> bool (button_pressed)
+##   - CheckBox in a group (radio) -> the selected radio's value attribute,
+##     keyed by the group name; unselected radios are absent
+##   - HSlider -> float
+##   - OptionButton (select) -> the selected item text
+##
+## Used by submit-button handlers to populate the form_submitted signal,
+## but also callable directly by consumers that want the current snapshot.
+func get_form_data() -> Dictionary:
+	var out: Dictionary = {}
+	var seen_groups: Dictionary = {}
+
+	for id in _elements_by_id.keys():
+		var control = _elements_by_id[id]
+		if not is_instance_valid(control):
+			continue
+		if control is LineEdit:
+			out[id] = (control as LineEdit).text
+		elif control is TextEdit:
+			out[id] = (control as TextEdit).text
+		elif control is HSlider:
+			out[id] = (control as HSlider).value
+		elif control is OptionButton:
+			var ob: OptionButton = control
+			out[id] = ob.get_item_text(ob.selected) if ob.selected >= 0 else ""
+		elif control is CheckBox:
+			var cb: CheckBox = control
+			if cb.button_group != null:
+				# Radio — keyed by group name, only the selected one. Track
+				# the group so we don't overwrite once we've found the winner.
+				continue
+			out[id] = cb.button_pressed
+
+	# Radios: find the pressed one per group, key by group name.
+	for group_name in _radio_groups.keys():
+		var bg: ButtonGroup = _radio_groups[group_name]
+		var pressed = bg.get_pressed_button()
+		if pressed != null:
+			out[group_name] = pressed.get_meta("value", "on")
+
+	return out
+
 
 #endregion

--- a/addons/gtml/src/css/GmlCssEval.gd
+++ b/addons/gtml/src/css/GmlCssEval.gd
@@ -12,8 +12,14 @@ extends RefCounted
 ## Substitute every var(--name) or var(--name, fallback) in ``raw`` with
 ## either the scope's value or the fallback. Returns the substituted string.
 ## Unknown vars without fallback resolve to the empty string and emit a
-## push_warning so authors notice.
+## push_warning so authors notice. Cycle detection is built in — a var
+## that references itself (directly or via a chain) breaks the chain on
+## re-entry with a warning, matching CSS's "invalid → initial" semantics.
 static func substitute_vars(raw: String, scope: Dictionary) -> String:
+	return _substitute_vars_internal(raw, scope, {})
+
+
+static func _substitute_vars_internal(raw: String, scope: Dictionary, visited: Dictionary) -> String:
 	if raw.find("var(") < 0:
 		return raw
 
@@ -21,14 +27,14 @@ static func substitute_vars(raw: String, scope: Dictionary) -> String:
 	var i := 0
 	var n := raw.length()
 	while i < n:
-		if i + 4 < n and raw.substr(i, 4) == "var(":
+		if i + 4 <= n and raw.substr(i, 4) == "var(":
 			var close := _find_paren_close(raw, i + 4)
 			if close < 0:
 				push_warning("GmlCssEval: unterminated var() in '%s'" % raw)
 				out += raw.substr(i)
 				break
 			var inner := raw.substr(i + 4, close - i - 4).strip_edges()
-			out += _resolve_var(inner, scope)
+			out += _resolve_var(inner, scope, visited)
 			i = close + 1
 		else:
 			out += raw[i]
@@ -36,7 +42,7 @@ static func substitute_vars(raw: String, scope: Dictionary) -> String:
 	return out
 
 
-static func _resolve_var(inner: String, scope: Dictionary) -> String:
+static func _resolve_var(inner: String, scope: Dictionary, visited: Dictionary) -> String:
 	# inner is "--name" or "--name, fallback"
 	var comma := _top_level_comma(inner)
 	var name: String
@@ -46,11 +52,17 @@ static func _resolve_var(inner: String, scope: Dictionary) -> String:
 	else:
 		name = inner.substr(0, comma).strip_edges()
 		fallback = inner.substr(comma + 1).strip_edges()
+
+	if visited.has(name):
+		push_warning("GmlCssEval: CSS variable cycle detected at '%s'" % name)
+		return ""
+
 	if scope.has(name):
-		# The scope value may itself contain var() — resolve recursively.
-		return substitute_vars(str(scope[name]), scope)
+		var next_visited := visited.duplicate()
+		next_visited[name] = true
+		return _substitute_vars_internal(str(scope[name]), scope, next_visited)
 	if not fallback.is_empty():
-		return substitute_vars(fallback, scope)
+		return _substitute_vars_internal(fallback, scope, visited)
 	push_warning("GmlCssEval: unknown CSS variable '%s' (no fallback)" % name)
 	return ""
 
@@ -70,7 +82,7 @@ static func evaluate_calc(raw: String) -> String:
 	var i := 0
 	var n := raw.length()
 	while i < n:
-		if i + 5 < n and raw.substr(i, 5) == "calc(":
+		if i + 5 <= n and raw.substr(i, 5) == "calc(":
 			var close := _find_paren_close(raw, i + 5)
 			if close < 0:
 				push_warning("GmlCssEval: unterminated calc() in '%s'" % raw)

--- a/addons/gtml/src/css/GmlCssEval.gd
+++ b/addons/gtml/src/css/GmlCssEval.gd
@@ -1,0 +1,262 @@
+class_name GmlCssEval
+extends RefCounted
+
+## Substitution + calc() evaluation for CSS values containing var() or calc().
+##
+## Operates on raw value strings; the result is a String that the property's
+## normal type parser (GmlCssParser.convert_value) then re-dispatches. This
+## keeps the type system unchanged — tokens just thread an extra resolve step
+## through it.
+
+
+## Substitute every var(--name) or var(--name, fallback) in ``raw`` with
+## either the scope's value or the fallback. Returns the substituted string.
+## Unknown vars without fallback resolve to the empty string and emit a
+## push_warning so authors notice.
+static func substitute_vars(raw: String, scope: Dictionary) -> String:
+	if raw.find("var(") < 0:
+		return raw
+
+	var out := ""
+	var i := 0
+	var n := raw.length()
+	while i < n:
+		if i + 4 < n and raw.substr(i, 4) == "var(":
+			var close := _find_paren_close(raw, i + 4)
+			if close < 0:
+				push_warning("GmlCssEval: unterminated var() in '%s'" % raw)
+				out += raw.substr(i)
+				break
+			var inner := raw.substr(i + 4, close - i - 4).strip_edges()
+			out += _resolve_var(inner, scope)
+			i = close + 1
+		else:
+			out += raw[i]
+			i += 1
+	return out
+
+
+static func _resolve_var(inner: String, scope: Dictionary) -> String:
+	# inner is "--name" or "--name, fallback"
+	var comma := _top_level_comma(inner)
+	var name: String
+	var fallback: String = ""
+	if comma < 0:
+		name = inner.strip_edges()
+	else:
+		name = inner.substr(0, comma).strip_edges()
+		fallback = inner.substr(comma + 1).strip_edges()
+	if scope.has(name):
+		# The scope value may itself contain var() — resolve recursively.
+		return substitute_vars(str(scope[name]), scope)
+	if not fallback.is_empty():
+		return substitute_vars(fallback, scope)
+	push_warning("GmlCssEval: unknown CSS variable '%s' (no fallback)" % name)
+	return ""
+
+
+## Evaluate every calc(...) in ``raw`` and replace it with the computed
+## scalar (with unit if all operands share one). Operations supported:
+## + - * /. No parentheses inside calc bodies — only the outer calc() itself.
+## Unit rules:
+##   - + and -: both sides must share the same unit (or both be unitless)
+##   - * and /: at most one side may carry a unit
+## Anything ambiguous is left as the raw substring so authors can spot it.
+static func evaluate_calc(raw: String) -> String:
+	if raw.find("calc(") < 0:
+		return raw
+
+	var out := ""
+	var i := 0
+	var n := raw.length()
+	while i < n:
+		if i + 5 < n and raw.substr(i, 5) == "calc(":
+			var close := _find_paren_close(raw, i + 5)
+			if close < 0:
+				push_warning("GmlCssEval: unterminated calc() in '%s'" % raw)
+				out += raw.substr(i)
+				break
+			var inner := raw.substr(i + 5, close - i - 5).strip_edges()
+			out += _eval_expr(inner)
+			i = close + 1
+		else:
+			out += raw[i]
+			i += 1
+	return out
+
+
+## Resolve var() then evaluate calc(). Convenience for the resolver.
+static func resolve(raw: String, scope: Dictionary) -> String:
+	return evaluate_calc(substitute_vars(raw, scope))
+
+
+# ─── Internals ────────────────────────────────────────────────────────
+
+
+static func _find_paren_close(s: String, from: int) -> int:
+	var depth := 1
+	var i := from
+	var n := s.length()
+	while i < n:
+		var ch := s[i]
+		if ch == "(":
+			depth += 1
+		elif ch == ")":
+			depth -= 1
+			if depth == 0:
+				return i
+		i += 1
+	return -1
+
+
+static func _top_level_comma(s: String) -> int:
+	var depth := 0
+	var i := 0
+	var n := s.length()
+	while i < n:
+		var ch := s[i]
+		if ch == "(":
+			depth += 1
+		elif ch == ")":
+			depth = maxi(0, depth - 1)
+		elif ch == "," and depth == 0:
+			return i
+		i += 1
+	return -1
+
+
+## Tokenize then evaluate a flat arithmetic expression with + - * /.
+## Returns the result formatted as "<number><unit>" or just "<number>".
+static func _eval_expr(expr: String) -> String:
+	var tokens := _tokenize(expr)
+	if tokens.is_empty():
+		return expr
+	# Pass 1: combine * and /
+	var pass1: Array = [tokens[0]]
+	var i := 1
+	while i < tokens.size():
+		var op = tokens[i]
+		var rhs = tokens[i + 1] if i + 1 < tokens.size() else null
+		if rhs == null:
+			break
+		if op == "*" or op == "/":
+			var lhs = pass1[pass1.size() - 1]
+			pass1[pass1.size() - 1] = _combine(lhs, rhs, op)
+		else:
+			pass1.append(op)
+			pass1.append(rhs)
+		i += 2
+	# Pass 2: combine + and - left-to-right
+	var acc = pass1[0]
+	var j := 1
+	while j < pass1.size():
+		var op = pass1[j]
+		var rhs = pass1[j + 1] if j + 1 < pass1.size() else null
+		if rhs == null:
+			break
+		acc = _combine(acc, rhs, op)
+		j += 2
+	return _format_operand(acc)
+
+
+## A token is either a String operator or a Dictionary {value: float, unit: String}.
+static func _tokenize(expr: String) -> Array:
+	var out: Array = []
+	var i := 0
+	var n := expr.length()
+	while i < n:
+		var ch := expr[i]
+		if ch == " " or ch == "\t" or ch == "\n":
+			i += 1
+			continue
+		if ch == "+" or ch == "-" or ch == "*" or ch == "/":
+			# Allow leading negative numbers when the previous token is an op (or none).
+			var is_unary := (ch == "-" or ch == "+") and (out.is_empty() or out[out.size() - 1] is String)
+			if is_unary:
+				var start := i
+				i += 1
+				while i < n and (expr[i].is_valid_int() or expr[i] == "."):
+					i += 1
+				var num_str := expr.substr(start, i - start)
+				var unit := ""
+				while i < n and expr[i].is_valid_identifier():
+					unit += expr[i]
+					i += 1
+				if i < n and expr[i] == "%":
+					unit = "%"
+					i += 1
+				out.append({"value": num_str.to_float(), "unit": unit})
+				continue
+			out.append(ch)
+			i += 1
+			continue
+		if ch.is_valid_int() or ch == ".":
+			var start := i
+			while i < n and (expr[i].is_valid_int() or expr[i] == "."):
+				i += 1
+			var num_str := expr.substr(start, i - start)
+			var unit := ""
+			while i < n and expr[i].is_valid_identifier():
+				unit += expr[i]
+				i += 1
+			if i < n and expr[i] == "%":
+				unit = "%"
+				i += 1
+			out.append({"value": num_str.to_float(), "unit": unit})
+			continue
+		# Unknown — bail by absorbing rest as a unit on the previous operand
+		i += 1
+	return out
+
+
+static func _combine(a, b, op: String):
+	if not (a is Dictionary) or not (b is Dictionary):
+		return a  # malformed — punt
+	var au: String = a.get("unit", "")
+	var bu: String = b.get("unit", "")
+	var av: float = a.get("value", 0.0)
+	var bv: float = b.get("value", 0.0)
+	var unit := ""
+	var value := 0.0
+	match op:
+		"+":
+			if au != bu and not (au.is_empty() or bu.is_empty()):
+				push_warning("GmlCssEval: cannot add %s and %s" % [au, bu])
+				return a
+			unit = au if not au.is_empty() else bu
+			value = av + bv
+		"-":
+			if au != bu and not (au.is_empty() or bu.is_empty()):
+				push_warning("GmlCssEval: cannot subtract %s and %s" % [bu, au])
+				return a
+			unit = au if not au.is_empty() else bu
+			value = av - bv
+		"*":
+			if not au.is_empty() and not bu.is_empty():
+				push_warning("GmlCssEval: cannot multiply two unit-bearing values (%s * %s)" % [au, bu])
+				return a
+			unit = au if not au.is_empty() else bu
+			value = av * bv
+		"/":
+			if not bu.is_empty():
+				push_warning("GmlCssEval: cannot divide by a unit-bearing value (%s)" % bu)
+				return a
+			if bv == 0.0:
+				push_warning("GmlCssEval: division by zero in calc()")
+				return a
+			unit = au
+			value = av / bv
+		_:
+			return a
+	return {"value": value, "unit": unit}
+
+
+static func _format_operand(op) -> String:
+	if not (op is Dictionary):
+		return str(op)
+	var value: float = op.get("value", 0.0)
+	var unit: String = op.get("unit", "")
+	# Render integers without a decimal so downstream type parsers stay clean.
+	if value == floor(value) and not is_inf(value):
+		return "%d%s" % [int(value), unit]
+	return "%s%s" % [str(value), unit]

--- a/addons/gtml/src/css/GmlCssEval.gd.uid
+++ b/addons/gtml/src/css/GmlCssEval.gd.uid
@@ -1,0 +1,1 @@
+uid://cho5gg1s1l67k

--- a/addons/gtml/src/css/GmlCssParser.gd
+++ b/addons/gtml/src/css/GmlCssParser.gd
@@ -253,8 +253,17 @@ func _parse_properties() -> Dictionary:
 
 		var prop_value := _parse_property_value()
 
-		# Parse the value into appropriate type
-		properties[prop_name] = _convert_property_value(prop_name, prop_value)
+		# Custom properties (--name) are stored as raw strings; the resolver
+		# substitutes them into var() references at compute-style time and
+		# routes the substituted value back through convert_value.
+		# Values containing var() or calc() are also deferred — the resolver
+		# can't type-parse them until the scope is known.
+		if prop_name.begins_with("--"):
+			properties[prop_name] = prop_value
+		elif prop_value.contains("var(") or prop_value.contains("calc("):
+			properties[prop_name] = {"_lazy": true, "raw": prop_value, "prop": prop_name}
+		else:
+			properties[prop_name] = _convert_property_value(prop_name, prop_value)
 
 		_skip_whitespace_and_comments()
 
@@ -323,9 +332,20 @@ func _skip_string(quote: String) -> void:
 		_advance()
 
 
+## Public entrypoint for converting a string value into the typed
+## representation for ``prop_name`` (Color, Dictionary, int, ...). Used by
+## the resolver after var() and calc() are substituted out of a lazy value.
+static func convert_value(prop_name: String, value: String):
+	return _convert_property_value_static(prop_name, value)
+
+
 ## Convert a property value string to the appropriate type.
 ## Dispatches to the appropriate value parser module.
 func _convert_property_value(prop_name: String, value: String):
+	return _convert_property_value_static(prop_name, value)
+
+
+static func _convert_property_value_static(prop_name: String, value: String):
 	# Passthrough properties (return as string)
 	if prop_name in PASSTHROUGH_PROPS:
 		return value

--- a/addons/gtml/src/css/GmlCssParser.gd
+++ b/addons/gtml/src/css/GmlCssParser.gd
@@ -400,6 +400,10 @@ static func _convert_property_value_static(prop_name: String, value: String):
 	if prop_name == "outline":
 		return GmlBorderValues.parse_outline(value)
 
+	# Transform: translate/scale/rotate composite
+	if prop_name == "transform":
+		return GmlTransformValues.parse_transform(value)
+
 	# Transition properties
 	if prop_name == "transition":
 		return GmlTransitionValues.parse_transition(value)

--- a/addons/gtml/src/css/GmlSelector.gd
+++ b/addons/gtml/src/css/GmlSelector.gd
@@ -24,7 +24,7 @@ extends RefCounted
 ## input events) but do NOT participate in DOM matching. Anything else with a
 ## ":" prefix is treated as a structural pseudo and routed through the
 ## matcher's structural-pseudo path.
-const STATE_PSEUDOS := ["hover", "active", "focus", "disabled"]
+const STATE_PSEUDOS := ["hover", "active", "focus", "disabled", "checked"]
 
 
 class Compound:

--- a/addons/gtml/src/css/GmlStyleResolver.gd
+++ b/addons/gtml/src/css/GmlStyleResolver.gd
@@ -16,23 +16,41 @@ extends RefCounted
 ## holding pseudo-class overrides.
 func resolve(root, rules: Array) -> Dictionary:
 	var styles: Dictionary = {}
-	_resolve_node(root, [], rules, styles)
+	_resolve_node(root, [], {}, rules, styles)
 	return styles
 
 
-func _resolve_node(node, ancestor_chain: Array, rules: Array, styles: Dictionary) -> void:
+## ``scope`` holds the cascade-accumulated custom properties (``--name`` -> raw
+## value string) inherited from this node's ancestors. Each node merges its
+## own ``--*`` declarations on top before passing the dict to its children, so
+## var() resolution at compute-style time only ever needs to look at one map.
+func _resolve_node(node, ancestor_chain: Array, scope: Dictionary, rules: Array, styles: Dictionary) -> void:
 	if node == null or node.is_text_node:
 		return
 
 	var chain := ancestor_chain.duplicate()
 	chain.append(node)
 
-	var computed := _compute_style(node, chain, rules)
+	# Build this node's scope by overlaying its own custom-property
+	# declarations (from any matching rule) onto the inherited scope. We do
+	# this BEFORE computing the style so var() lookups against the node's
+	# own props work the same way as ancestor-defined ones.
+	var child_scope := scope.duplicate()
+	for rule in rules:
+		if rule.selector == null:
+			continue
+		if not GmlSelector.matches(rule.selector, chain):
+			continue
+		for key in rule.properties:
+			if str(key).begins_with("--"):
+				child_scope[key] = rule.properties[key]
+
+	var computed := _compute_style(node, chain, rules, child_scope)
 	if not computed.is_empty():
 		styles[node] = computed
 
 	for child in node.children:
-		_resolve_node(child, chain, rules, styles)
+		_resolve_node(child, chain, child_scope, rules, styles)
 
 
 ## Walks all rules, gathers the matching ones for ``node``, sorts them by
@@ -45,7 +63,7 @@ func _resolve_node(node, ancestor_chain: Array, rules: Array, styles: Dictionary
 ## ``a:hover:focus`` and ``a:focus:hover`` produce the same ``_focus+hover``
 ## key). A rule whose pseudo set contains any unknown state pseudo is dropped
 ## with a warning — see test_multi_pseudo.
-func _compute_style(node, ancestor_chain: Array, rules: Array) -> Dictionary:
+func _compute_style(node, ancestor_chain: Array, rules: Array, scope: Dictionary = {}) -> Dictionary:
 	var matches: Array = []
 
 	for rule in rules:
@@ -97,7 +115,36 @@ func _compute_style(node, ancestor_chain: Array, rules: Array) -> Dictionary:
 	for key in state_buckets:
 		style["_" + key] = state_buckets[key]
 
+	# Resolve lazy values (var() / calc()) against this node's scope, then
+	# re-dispatch through the type parser. Custom-property keys (--*) are
+	# scope-only and never part of the rendered style — strip them now.
+	_resolve_lazy_values(style, scope)
+	for bucket_key in state_buckets:
+		_resolve_lazy_values(style["_" + bucket_key], scope)
+
 	return style
+
+
+## Walk a flat style dict in place: resolve any lazy {_lazy,raw,prop} value
+## through GmlCssEval (var() substitution + calc() evaluation) and re-dispatch
+## through the type parser, and drop --* custom-property keys (they belong
+## to the cascade scope, not the rendered style).
+static func _resolve_lazy_values(style: Dictionary, scope: Dictionary) -> void:
+	var to_drop: Array = []
+	for key in style.keys():
+		var k := str(key)
+		if k.begins_with("--"):
+			to_drop.append(key)
+			continue
+		if k.begins_with("_"):
+			continue  # state buckets are dicts, recursed by the caller
+		var v = style[key]
+		if v is Dictionary and v.get("_lazy", false):
+			var raw: String = v.get("raw", "")
+			var resolved: String = GmlCssEval.resolve(raw, scope)
+			style[key] = GmlCssParser.convert_value(k, resolved)
+	for k in to_drop:
+		style.erase(k)
 
 
 ## All state pseudos on the selector's rightmost compound, in source order.

--- a/addons/gtml/src/css/values/GmlTransformValues.gd
+++ b/addons/gtml/src/css/values/GmlTransformValues.gd
@@ -1,0 +1,99 @@
+class_name GmlTransformValues
+extends RefCounted
+
+## Parser for CSS ``transform`` values.
+##
+## Supported functions: translate(x[, y]) — px only, scale(s|sx, sy), rotate(deg).
+## Multiple functions in one value compose left-to-right; later writes overwrite
+## earlier ones for the same axis, matching the rule that the rightmost
+## transform in a chain wins per CSS ordering.
+##
+## Returns a Dictionary with default keys so consumers don't have to check:
+##   {translate: Vector2.ZERO, scale: Vector2.ONE, rotate: 0.0}
+
+
+static func parse_transform(raw: String) -> Dictionary:
+	var out: Dictionary = {"translate": Vector2.ZERO, "scale": Vector2.ONE, "rotate": 0.0}
+	var s := raw.strip_edges()
+
+	# Walk function calls: name(args) name(args) ...
+	var i := 0
+	var n := s.length()
+	while i < n:
+		while i < n and (s[i] == " " or s[i] == "\t"):
+			i += 1
+		if i >= n:
+			break
+		var fn_start := i
+		while i < n and s[i] != "(" and s[i] != " ":
+			i += 1
+		var fn_name: String = s.substr(fn_start, i - fn_start).to_lower()
+		if i >= n or s[i] != "(":
+			push_warning("GmlTransformValues: expected '(' after '%s' in '%s'" % [fn_name, raw])
+			break
+		var args_start := i + 1
+		var close := s.find(")", args_start)
+		if close < 0:
+			push_warning("GmlTransformValues: unterminated function '%s(' in '%s'" % [fn_name, raw])
+			break
+		var args := s.substr(args_start, close - args_start)
+		_apply_function(out, fn_name, args)
+		i = close + 1
+	return out
+
+
+static func _apply_function(out: Dictionary, name: String, args_raw: String) -> void:
+	var args := []
+	for part in args_raw.split(",", false):
+		args.append(part.strip_edges())
+	match name:
+		"translate":
+			var x: float = _strip_unit_to_float(args[0]) if args.size() > 0 else 0.0
+			var y: float = _strip_unit_to_float(args[1]) if args.size() > 1 else 0.0
+			out["translate"] = Vector2(x, y)
+		"translatex":
+			out["translate"] = Vector2(_strip_unit_to_float(args[0]) if args.size() > 0 else 0.0, out["translate"].y)
+		"translatey":
+			out["translate"] = Vector2(out["translate"].x, _strip_unit_to_float(args[0]) if args.size() > 0 else 0.0)
+		"scale":
+			var sx: float = _strip_unit_to_float(args[0]) if args.size() > 0 else 1.0
+			var sy: float = _strip_unit_to_float(args[1]) if args.size() > 1 else sx
+			out["scale"] = Vector2(sx, sy)
+		"scalex":
+			out["scale"] = Vector2(_strip_unit_to_float(args[0]) if args.size() > 0 else 1.0, out["scale"].y)
+		"scaley":
+			out["scale"] = Vector2(out["scale"].x, _strip_unit_to_float(args[0]) if args.size() > 0 else 1.0)
+		"rotate":
+			# Accept "45deg", "0.5rad", or bare number (treat as degrees).
+			var raw: String = args[0] if args.size() > 0 else "0"
+			out["rotate"] = _parse_angle_to_radians(raw)
+		_:
+			push_warning("GmlTransformValues: unsupported transform function '%s'" % name)
+
+
+## Parse a numeric argument, ignoring any trailing px / unit suffix.
+static func _strip_unit_to_float(s: String) -> float:
+	var trimmed := s.strip_edges()
+	var i := 0
+	var n := trimmed.length()
+	# Allow a leading sign and digits + decimal point.
+	while i < n:
+		var ch := trimmed[i]
+		if (i == 0 and (ch == "-" or ch == "+")) or ch.is_valid_int() or ch == ".":
+			i += 1
+		else:
+			break
+	return trimmed.substr(0, i).to_float()
+
+
+static func _parse_angle_to_radians(s: String) -> float:
+	var trimmed := s.strip_edges().to_lower()
+	if trimmed.ends_with("rad"):
+		return trimmed.substr(0, trimmed.length() - 3).strip_edges().to_float()
+	if trimmed.ends_with("turn"):
+		return trimmed.substr(0, trimmed.length() - 4).strip_edges().to_float() * TAU
+	# Default + "deg" — degrees
+	var num: String = trimmed
+	if num.ends_with("deg"):
+		num = num.substr(0, num.length() - 3).strip_edges()
+	return deg_to_rad(num.to_float())

--- a/addons/gtml/src/css/values/GmlTransformValues.gd.uid
+++ b/addons/gtml/src/css/values/GmlTransformValues.gd.uid
@@ -1,0 +1,1 @@
+uid://cymbr5te2kfu

--- a/addons/gtml/src/html_parser/GmlHtmlParser.gd
+++ b/addons/gtml/src/html_parser/GmlHtmlParser.gd
@@ -27,6 +27,33 @@ var _pos: int = 0
 var _html: String = ""
 var _length: int = 0
 var _depth: int = 0
+var _warnings: Array = []  # [{line:int, col:int, msg:String}]
+
+
+## Get all warnings emitted during the last parse. Each entry: {line, col, msg}.
+## Mirrors GmlCssParser.get_warnings() so editor tooling can surface both
+## parsers' diagnostics through a single interface.
+func get_warnings() -> Array:
+	return _warnings
+
+
+func _line_col_for(p: int) -> Dictionary:
+	var line := 1
+	var col := 1
+	var limit: int = mini(p, _length)
+	for i in range(limit):
+		if _html[i] == "\n":
+			line += 1
+			col = 1
+		else:
+			col += 1
+	return {"line": line, "col": col}
+
+
+func _warn(msg: String) -> void:
+	var lc := _line_col_for(_pos)
+	_warnings.append({"line": lc["line"], "col": lc["col"], "msg": msg})
+	push_warning("GmlHtmlParser [%d:%d]: %s" % [lc["line"], lc["col"], msg])
 
 
 ## Parse HTML string and return the root node.
@@ -36,6 +63,7 @@ func parse(html: String):
 	_pos = 0
 	_length = html.length()
 	_depth = 0
+	_warnings.clear()
 
 	# Create a virtual root to hold multiple top-level elements
 	var root = GmlNodeScript.create_element("_root")
@@ -109,7 +137,7 @@ func _parse_element():
 	# Parse tag name
 	var tag_name := _parse_identifier()
 	if tag_name.is_empty():
-		push_warning("GmlHtmlParser: Expected tag name at position %d" % _pos)
+		_warn("Expected tag name")
 		_depth -= 1
 		return null
 
@@ -127,7 +155,7 @@ func _parse_element():
 		is_self_closing = true
 
 	if not _consume(">"):
-		push_warning("GmlHtmlParser: Expected '>' at position %d" % _pos)
+		_warn("Expected '>'")
 		# Try to recover by finding the next >
 		while _pos < _length and _peek() != ">":
 			_advance()
@@ -206,7 +234,7 @@ func _parse_closing_tag(expected_tag: String) -> bool:
 
 	var tag_name := _parse_identifier()
 	if tag_name.to_lower() != expected_tag:
-		push_warning("GmlHtmlParser: Expected closing tag </%s> but found </%s>" % [expected_tag, tag_name])
+		_warn("Expected closing tag </%s> but found </%s>" % [expected_tag, tag_name])
 
 	_skip_whitespace()
 	_consume(">")

--- a/addons/gtml/src/html_renderer/GmlDimensions.gd
+++ b/addons/gtml/src/html_renderer/GmlDimensions.gd
@@ -47,6 +47,49 @@ static func apply(control: Control, style: Dictionary) -> void:
 	if style.has("cursor"):
 		control.mouse_default_cursor_shape = parse_cursor(style["cursor"])
 
+	if style.has("transform"):
+		_apply_transform(control, style["transform"])
+
+
+## Apply a parsed transform Dictionary to a Control. Maps:
+##   translate -> position offset (added to the layout-driven position)
+##   scale     -> Control.scale
+##   rotate    -> Control.rotation (radians)
+## pivot_offset is recomputed to the control's size center so scale/rotate
+## behave like CSS transform-origin: 50% 50%. Done deferred to a process
+## frame so we have a valid post-layout size to anchor on.
+static func _apply_transform(control: Control, t: Dictionary) -> void:
+	var translate: Vector2 = t.get("translate", Vector2.ZERO)
+	var scale_v: Vector2 = t.get("scale", Vector2.ONE)
+	var rotate_v: float = t.get("rotate", 0.0)
+
+	# Apply scalar transforms immediately — position offset waits for layout.
+	control.scale = scale_v
+	control.rotation = rotate_v
+
+	if translate != Vector2.ZERO or scale_v != Vector2.ONE or rotate_v != 0.0:
+		var ref := weakref(control)
+		control.set_meta("_transform_translate", translate)
+		# Recompute pivot + position once the Control has been sized by its
+		# Container. Re-applies on resize so dynamic layouts keep their
+		# transform-origin centered.
+		var update_pivot := func():
+			var c = ref.get_ref()
+			if c == null or not is_instance_valid(c):
+				return
+			c.pivot_offset = c.size * 0.5
+			var off: Vector2 = c.get_meta("_transform_translate", Vector2.ZERO)
+			c.position = c.get_meta("_transform_base_position", c.position) + off
+		control.tree_entered.connect(func():
+			var c = ref.get_ref()
+			if c == null or not is_instance_valid(c):
+				return
+			c.set_meta("_transform_base_position", c.position)
+			c.get_tree().process_frame.connect(update_pivot, CONNECT_ONE_SHOT)
+			if not c.resized.is_connected(update_pivot):
+				c.resized.connect(update_pivot)
+		, CONNECT_ONE_SHOT)
+
 
 ## Apply width or height. Returns the percent fraction if percent-based, else -1.
 static func _apply_axis(control: Control, dim: Variant, is_width: bool) -> float:

--- a/addons/gtml/src/html_renderer/elements/GmlInputBuilder.gd
+++ b/addons/gtml/src/html_renderer/elements/GmlInputBuilder.gd
@@ -124,6 +124,7 @@ static func _build_checkbox_input(node, style: Dictionary, gml_view, defaults: D
 		)
 
 	_apply_button_focus_stylebox(checkbox, style)
+	_apply_button_checked_stylebox(checkbox, style)
 	return checkbox
 
 
@@ -174,7 +175,38 @@ static func _build_radio_input(node, style: Dictionary, gml_view, defaults: Dict
 		)
 
 	_apply_button_focus_stylebox(radio, style)
+	_apply_button_checked_stylebox(radio, style)
 	return radio
+
+
+## Apply a CSS-driven :checked stylebox to a CheckBox / radio. Godot draws
+## the "pressed" stylebox while button_pressed is true (toggle buttons treat
+## "pressed" as the checked state), so we install the :checked bucket's
+## visual onto that slot. Empty :checked rule still wins over default —
+## installs StyleBoxEmpty to silence Godot's pressed indicator.
+static func _apply_button_checked_stylebox(btn: CheckBox, style: Dictionary) -> void:
+	if not style.has("_checked"):
+		return
+	var checked_style: Dictionary = style["_checked"]
+	var has_visual := false
+	var box := StyleBoxFlat.new()
+	box.bg_color = Color.TRANSPARENT
+	if checked_style.has("background-color"):
+		box.bg_color = checked_style["background-color"]
+		has_visual = true
+	if checked_style.has("border") or checked_style.has("border-width") or checked_style.has("border-color"):
+		GmlStyles.apply_border_to_stylebox(box, checked_style)
+		has_visual = true
+	if checked_style.has("border-radius"):
+		box.corner_radius_top_left = checked_style["border-radius"]
+		box.corner_radius_top_right = checked_style["border-radius"]
+		box.corner_radius_bottom_left = checked_style["border-radius"]
+		box.corner_radius_bottom_right = checked_style["border-radius"]
+		has_visual = true
+	if not has_visual:
+		btn.add_theme_stylebox_override("pressed", StyleBoxEmpty.new())
+		return
+	btn.add_theme_stylebox_override("pressed", box)
 
 
 ## Apply a CSS-driven :focus stylebox to a CheckBox / radio so authors can

--- a/addons/gtml/src/html_renderer/elements/GmlInputBuilder.gd
+++ b/addons/gtml/src/html_renderer/elements/GmlInputBuilder.gd
@@ -88,6 +88,11 @@ static func _build_text_input(node, input_type: String, style: Dictionary, gml_v
 				view.input_changed.emit(input_id, new_text)
 		)
 
+	# Optional @keydown="handler" — forwards key events to the GmlView's
+	# key_pressed signal so user scripts can implement search/autocomplete
+	# without touching the underlying LineEdit directly.
+	_wire_keydown(line_edit, node, gml_view)
+
 	line_edit.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 
 	return line_edit
@@ -177,6 +182,28 @@ static func _build_radio_input(node, style: Dictionary, gml_view, defaults: Dict
 	_apply_button_focus_stylebox(radio, style)
 	_apply_button_checked_stylebox(radio, style)
 	return radio
+
+
+## Connect the input's gui_input signal to emit GmlView.key_pressed when an
+## ``@keydown="handler"`` attribute is present. Filters to actual key-down
+## events (skips key-up, mouse, and other input event types).
+static func _wire_keydown(control: Control, node, gml_view) -> void:
+	if gml_view == null:
+		return
+	var handler: String = node.get_attr("@keydown", "")
+	if handler.is_empty():
+		return
+	var view_ref = weakref(gml_view)
+	control.gui_input.connect(func(event: InputEvent):
+		if not (event is InputEventKey):
+			return
+		if not event.pressed:
+			return
+		var view = view_ref.get_ref()
+		if view == null:
+			return
+		view.key_pressed.emit(handler, event)
+	)
 
 
 ## Apply a CSS-driven :checked stylebox to a CheckBox / radio. Godot draws
@@ -317,14 +344,18 @@ static func _build_submit_button(node, style: Dictionary, ctx: Dictionary) -> Co
 	button.text = value
 
 	if gml_view != null:
-		var click_handler = node.get_attr("@click", "")
-		if not click_handler.is_empty():
-			var view_ref = weakref(gml_view)
-			button.pressed.connect(func():
-				var view = view_ref.get_ref()
-				if view != null:
-					view.button_clicked.emit(click_handler)
-			)
+		var view_ref = weakref(gml_view)
+		var click_handler: String = node.get_attr("@click", "")
+		button.pressed.connect(func():
+			var view = view_ref.get_ref()
+			if view == null:
+				return
+			# Submit buttons always emit form_submitted with the current
+			# form snapshot, in addition to firing any optional @click.
+			view.form_submitted.emit(view.get_form_data())
+			if not click_handler.is_empty():
+				view.button_clicked.emit(click_handler)
+		)
 
 	return button
 

--- a/tests/unit/test_checked_pseudo.gd
+++ b/tests/unit/test_checked_pseudo.gd
@@ -1,0 +1,88 @@
+extends GutTest
+
+## v0.4: :checked pseudo-class for checkboxes and radio inputs.
+##
+## The resolver routes :checked rules into a _checked state bucket
+## (joining :hover/:focus/:active/:disabled). The input builders watch the
+## toggled signal and apply the bucket's properties as a Godot "pressed"
+## stylebox so the checked state is visually distinct.
+
+const GmlHtmlParserScript = preload("res://addons/gtml/src/html_parser/GmlHtmlParser.gd")
+const GmlCssParserScript = preload("res://addons/gtml/src/css/GmlCssParser.gd")
+const GmlStyleResolverScript = preload("res://addons/gtml/src/css/GmlStyleResolver.gd")
+const GmlViewScript = preload("res://addons/gtml/src/GmlView.gd")
+
+
+func _resolved_style(html: String, css: String, id: String) -> Dictionary:
+	var dom = GmlHtmlParserScript.new().parse(html)
+	var rules := GmlCssParserScript.new().parse(css)
+	var styles: Dictionary = GmlStyleResolverScript.new().resolve(dom, rules)
+	var node = _find_by_id(dom, id)
+	if node == null:
+		return {}
+	return styles.get(node, {})
+
+
+func _find_by_id(node, id: String):
+	if node == null or node.is_text_node:
+		return null
+	if node.get_id() == id:
+		return node
+	for c in node.children:
+		var r = _find_by_id(c, id)
+		if r != null:
+			return r
+	return null
+
+
+func test_checked_resolves_to_state_bucket() -> void:
+	var s := _resolved_style(
+		'<input id="cb" type="checkbox">',
+		'input { background-color: gray; } input:checked { background-color: red; }',
+		"cb")
+	assert_true(s.has("_checked"),
+		"resolver must emit _checked bucket from :checked rule, got keys: %s" % str(s.keys()))
+	assert_eq(s["_checked"].get("background-color"), Color.RED)
+
+
+func test_unknown_pseudo_still_dropped_when_combined_with_checked() -> void:
+	# :checked is now a valid state pseudo; a typo combined with it must
+	# still drop the whole rule rather than silently routing into _checked.
+	var s := _resolved_style(
+		'<input id="cb" type="checkbox">',
+		'input:checked:typoed { background-color: red; }',
+		"cb")
+	assert_false(s.has("_checked"), "rule with unknown pseudo must be dropped wholesale")
+
+
+func test_checked_bucket_in_runtime_view() -> void:
+	# End-to-end: a CheckBox with a :checked rule should apply a "pressed"
+	# stylebox override after build, so Godot draws the rule's appearance
+	# when button_pressed becomes true.
+	var dir := "res://tests/snapshots/.actual/checked_fixture"
+	var html_path := dir + "/index.html"
+	var css_path := dir + "/style.css"
+	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(dir))
+	var fh := FileAccess.open(html_path, FileAccess.WRITE)
+	fh.store_string('<input id="cb" type="checkbox" checked>')
+	fh.close()
+	var fc := FileAccess.open(css_path, FileAccess.WRITE)
+	fc.store_string('input:checked { background-color: rgb(155, 126, 255); }')
+	fc.close()
+
+	var view: GmlView = GmlViewScript.new()
+	view.html_path = html_path
+	view.css_path = css_path
+	view.size = Vector2(200, 100)
+	add_child_autofree(view)
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	var cb = view.get_element_by_id("cb")
+	assert_not_null(cb)
+	assert_true(cb is CheckBox)
+	assert_true(cb.has_theme_stylebox_override("pressed"),
+		"a CheckBox with a :checked rule should install a 'pressed' theme stylebox")
+	var sb = cb.get_theme_stylebox("pressed")
+	assert_true(sb is StyleBoxFlat)
+	assert_eq((sb as StyleBoxFlat).bg_color, Color(155.0 / 255.0, 126.0 / 255.0, 255.0 / 255.0))

--- a/tests/unit/test_checked_pseudo.gd.uid
+++ b/tests/unit/test_checked_pseudo.gd.uid
@@ -1,0 +1,1 @@
+uid://c45uwfek6tsdi

--- a/tests/unit/test_css_tokens.gd
+++ b/tests/unit/test_css_tokens.gd
@@ -1,0 +1,121 @@
+extends GutTest
+
+## v0.4: CSS custom properties (--name) and calc() resolution.
+##
+## Custom properties cascade through the DOM; var(--name) substitutes at
+## resolve time against the cumulative ancestor scope. calc() evaluates
+## simple arithmetic on numeric values with units.
+
+const GmlHtmlParserScript = preload("res://addons/gtml/src/html_parser/GmlHtmlParser.gd")
+const GmlCssParserScript = preload("res://addons/gtml/src/css/GmlCssParser.gd")
+const GmlStyleResolverScript = preload("res://addons/gtml/src/css/GmlStyleResolver.gd")
+
+
+func _style_for_id(html: String, css: String, id: String) -> Dictionary:
+	var dom = GmlHtmlParserScript.new().parse(html)
+	var rules := GmlCssParserScript.new().parse(css)
+	var styles: Dictionary = GmlStyleResolverScript.new().resolve(dom, rules)
+	var node = _find_by_id(dom, id)
+	if node == null:
+		return {}
+	return styles.get(node, {})
+
+
+func _find_by_id(node, id: String):
+	if node == null or node.is_text_node:
+		return null
+	if node.get_id() == id:
+		return node
+	for c in node.children:
+		var r = _find_by_id(c, id)
+		if r != null:
+			return r
+	return null
+
+
+#region Custom properties — declaration + substitution
+
+
+func test_var_substitution_same_rule() -> void:
+	# A custom prop declared on the same selector — should resolve.
+	var s := _style_for_id(
+		"<div id='target'>x</div>",
+		"div { --brand: red; color: var(--brand); }",
+		"target")
+	assert_eq(s.get("color"), Color.RED)
+
+
+func test_var_substitution_from_ancestor_scope() -> void:
+	# Custom prop on the parent should inherit to children's scope.
+	var s := _style_for_id(
+		"<div class='root'><p id='target'>x</p></div>",
+		".root { --brand: blue; } p { color: var(--brand); }",
+		"target")
+	assert_eq(s.get("color"), Color.BLUE)
+
+
+func test_var_with_fallback() -> void:
+	# var(--undefined, fallback) should use the fallback when the variable
+	# is not in scope.
+	var s := _style_for_id(
+		"<p id='target'>x</p>",
+		"p { color: var(--missing, red); }",
+		"target")
+	assert_eq(s.get("color"), Color.RED)
+
+
+func test_inner_scope_overrides_outer() -> void:
+	# A redeclaration on a deeper scope must shadow the outer one for that
+	# subtree.
+	var s := _style_for_id(
+		"<div class='outer'><div class='inner'><p id='target'>x</p></div></div>",
+		".outer { --brand: red; } .inner { --brand: blue; } p { color: var(--brand); }",
+		"target")
+	assert_eq(s.get("color"), Color.BLUE)
+
+
+func test_var_in_dimension_property() -> void:
+	# Variables in dimension props (width/padding) round-trip through the
+	# numeric type parser after substitution.
+	var s := _style_for_id(
+		"<div id='target'>x</div>",
+		"div { --pad: 24px; padding: var(--pad); }",
+		"target")
+	assert_eq(s.get("padding"), 24)
+
+
+#endregion
+
+
+#region calc()
+
+
+func test_calc_arithmetic_int() -> void:
+	var s := _style_for_id(
+		"<div id='target'>x</div>",
+		"div { padding: calc(16 + 8); }",
+		"target")
+	assert_eq(s.get("padding"), 24)
+
+
+func test_calc_with_units_px() -> void:
+	var s := _style_for_id(
+		"<div id='target'>x</div>",
+		"div { width: calc(200px + 40px); }",
+		"target")
+	var w = s.get("width")
+	assert_true(w is Dictionary)
+	assert_eq(w.get("unit"), "px")
+	assert_eq(w.get("value"), 240)
+
+
+func test_calc_with_var() -> void:
+	# calc() composes with var() — the var resolves first, then arithmetic.
+	var s := _style_for_id(
+		"<div id='target'>x</div>",
+		"div { --base: 16; padding: calc(var(--base) * 2); }",
+		"target")
+	assert_eq(s.get("padding"), 32)
+
+
+#endregion

--- a/tests/unit/test_css_tokens.gd.uid
+++ b/tests/unit/test_css_tokens.gd.uid
@@ -1,0 +1,1 @@
+uid://daatvusr6aoj

--- a/tests/unit/test_forms_and_keys.gd
+++ b/tests/unit/test_forms_and_keys.gd
@@ -1,0 +1,149 @@
+extends GutTest
+
+## v0.4: form value collection on submit + @keydown event attribute.
+##
+## GmlView.get_form_data() walks the registered inputs and returns
+## {id: value} for text inputs, checkboxes, radios (only the selected
+## one per group), sliders, and selects. Submit buttons trigger the
+## form_submitted signal with that dict.
+##
+## @keydown="handler" on an input fires the key_pressed signal with the
+## handler name + the InputEventKey.
+
+const GmlViewScript = preload("res://addons/gtml/src/GmlView.gd")
+
+
+func _build_view(html: String) -> GmlView:
+	var dir := "res://tests/snapshots/.actual/forms_keys_fixture"
+	var html_path := dir + "/index.html"
+	var css_path := dir + "/style.css"
+	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(dir))
+	var fh := FileAccess.open(html_path, FileAccess.WRITE)
+	fh.store_string(html)
+	fh.close()
+	var fc := FileAccess.open(css_path, FileAccess.WRITE)
+	fc.store_string("")
+	fc.close()
+
+	var view: GmlView = GmlViewScript.new()
+	view.html_path = html_path
+	view.css_path = css_path
+	view.size = Vector2(400, 300)
+	add_child_autofree(view)
+	return view
+
+
+#region Form value collection
+
+
+func test_get_form_data_collects_text_inputs() -> void:
+	var view := _build_view(
+		'<form><input id="name" type="text" value="Ada"><input id="email" type="text" value="ada@example.com"></form>'
+	)
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	assert_true(view.has_method("get_form_data"), "GmlView should expose get_form_data()")
+	var data: Dictionary = view.get_form_data()
+	assert_eq(data.get("name"), "Ada")
+	assert_eq(data.get("email"), "ada@example.com")
+
+
+func test_get_form_data_collects_checkbox_state() -> void:
+	var view := _build_view(
+		'<form><input id="opt_in" type="checkbox" checked><input id="opt_out" type="checkbox"></form>'
+	)
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	var data: Dictionary = view.get_form_data()
+	assert_eq(data.get("opt_in"), true)
+	assert_eq(data.get("opt_out"), false)
+
+
+func test_get_form_data_collects_selected_radio_only() -> void:
+	var view := _build_view(
+		'<form>'
+		+ '<input id="r1" type="radio" name="size" value="s">'
+		+ '<input id="r2" type="radio" name="size" value="m" checked>'
+		+ '<input id="r3" type="radio" name="size" value="l">'
+		+ '</form>'
+	)
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	var data: Dictionary = view.get_form_data()
+	# Only the selected radio's value appears — keyed by the group name.
+	assert_eq(data.get("size"), "m")
+	# Unselected radios are not in the dict.
+	assert_false(data.has("r1"))
+	assert_false(data.has("r3"))
+
+
+func test_submit_button_emits_form_submitted_with_data() -> void:
+	var view := _build_view(
+		'<form>'
+		+ '<input id="title" type="text" value="hello">'
+		+ '<input type="submit" value="Save">'
+		+ '</form>'
+	)
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	var emitted := []
+	view.form_submitted.connect(func(data: Dictionary):
+		emitted.append(data)
+	)
+
+	# Find the submit button and "click" it.
+	var btn: Button = _find_button(view, "Save")
+	assert_not_null(btn)
+	btn.pressed.emit()
+
+	assert_eq(emitted.size(), 1, "form_submitted should fire exactly once")
+	assert_eq(emitted[0].get("title"), "hello")
+
+
+#endregion
+
+
+#region @keydown
+
+
+func test_keydown_attribute_emits_key_pressed() -> void:
+	var view := _build_view(
+		'<input id="search" type="text" @keydown="on_search_key">'
+	)
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	assert_true(view.has_signal("key_pressed"), "GmlView should expose key_pressed signal")
+
+	var emitted := []
+	view.key_pressed.connect(func(handler: String, key: InputEvent):
+		emitted.append({"handler": handler, "keycode": key.keycode if key is InputEventKey else 0})
+	)
+
+	var input = view.get_element_by_id("search")
+	assert_not_null(input)
+	var ev := InputEventKey.new()
+	ev.keycode = KEY_A
+	ev.pressed = true
+	input.gui_input.emit(ev)
+
+	assert_eq(emitted.size(), 1)
+	assert_eq(emitted[0]["handler"], "on_search_key")
+	assert_eq(emitted[0]["keycode"], KEY_A)
+
+
+#endregion
+
+
+func _find_button(node: Node, label: String):
+	if node is Button and (node as Button).text == label:
+		return node
+	for child in node.get_children():
+		var r = _find_button(child, label)
+		if r != null:
+			return r
+	return null

--- a/tests/unit/test_forms_and_keys.gd.uid
+++ b/tests/unit/test_forms_and_keys.gd.uid
@@ -1,0 +1,1 @@
+uid://b64wefjqncu5

--- a/tests/unit/test_parser_robustness.gd
+++ b/tests/unit/test_parser_robustness.gd
@@ -82,3 +82,16 @@ func test_malformed_empty_closing_tag_terminates() -> void:
 	assert_not_null(dom1)
 	var dom2 = _parse("<p>a</  ></p>")
 	assert_not_null(dom2)
+
+
+func test_html_parser_records_warnings_with_line_col() -> void:
+	# get_warnings() mirrors the CSS parser's contract: each warning carries
+	# {line, col, msg} so the editor overlay can offer click-to-jump.
+	var parser = GmlHtmlParserScript.new()
+	parser.parse("<div>\n<p>a</q>\n</div>")
+	var warnings: Array = parser.get_warnings()
+	assert_true(warnings.size() > 0, "expected at least one warning for mismatched </q>")
+	var w = warnings[0]
+	assert_true(w.has("line"))
+	assert_true(w.has("col"))
+	assert_true(w.has("msg"))

--- a/tests/unit/test_transforms.gd
+++ b/tests/unit/test_transforms.gd
@@ -1,0 +1,120 @@
+extends GutTest
+
+## v0.4: CSS transform property — translate / scale / rotate.
+##
+## Maps to Control.position / scale / rotation. Multiple transforms compose
+## left-to-right. pivot_offset defaults to size/2 so scale/rotate behave
+## like CSS's default transform-origin: 50% 50%.
+
+const GmlCssParserScript = preload("res://addons/gtml/src/css/GmlCssParser.gd")
+const GmlViewScript = preload("res://addons/gtml/src/GmlView.gd")
+
+
+func _parse(css: String) -> Array:
+	return GmlCssParserScript.new().parse(css)
+
+
+#region Transform value parsing
+
+
+func test_translate_parses_to_vector() -> void:
+	var rules := _parse("div { transform: translate(10px, 20px); }")
+	var t = rules[0].properties.get("transform")
+	assert_true(t is Dictionary)
+	assert_eq(t.get("translate"), Vector2(10, 20))
+
+
+func test_translate_single_arg_uses_zero_y() -> void:
+	var rules := _parse("div { transform: translate(15px); }")
+	var t = rules[0].properties.get("transform")
+	assert_eq(t.get("translate"), Vector2(15, 0))
+
+
+func test_scale_uniform() -> void:
+	var rules := _parse("div { transform: scale(1.05); }")
+	var t = rules[0].properties.get("transform")
+	assert_eq(t.get("scale"), Vector2(1.05, 1.05))
+
+
+func test_scale_x_y() -> void:
+	var rules := _parse("div { transform: scale(1.1, 0.9); }")
+	var t = rules[0].properties.get("transform")
+	assert_eq(t.get("scale"), Vector2(1.1, 0.9))
+
+
+func test_rotate_deg_converts_to_radians() -> void:
+	var rules := _parse("div { transform: rotate(45deg); }")
+	var t = rules[0].properties.get("transform")
+	# 45 degrees == PI / 4 radians
+	assert_almost_eq(t.get("rotate"), PI / 4.0, 0.001)
+
+
+func test_multiple_transforms_combine() -> void:
+	var rules := _parse("div { transform: translate(10px, 0) scale(1.05) rotate(10deg); }")
+	var t = rules[0].properties.get("transform")
+	assert_eq(t.get("translate"), Vector2(10, 0))
+	assert_eq(t.get("scale"), Vector2(1.05, 1.05))
+	assert_almost_eq(t.get("rotate"), PI / 18.0, 0.001)
+
+
+#endregion
+
+
+#region Runtime application
+
+
+func _build_view_with(html: String, css: String) -> GmlView:
+	var dir := "res://tests/snapshots/.actual/transform_fixture"
+	var html_path := dir + "/index.html"
+	var css_path := dir + "/style.css"
+	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(dir))
+	var fh := FileAccess.open(html_path, FileAccess.WRITE)
+	fh.store_string(html)
+	fh.close()
+	var fc := FileAccess.open(css_path, FileAccess.WRITE)
+	fc.store_string(css)
+	fc.close()
+
+	var view: GmlView = GmlViewScript.new()
+	view.html_path = html_path
+	view.css_path = css_path
+	view.size = Vector2(400, 300)
+	add_child_autofree(view)
+	return view
+
+
+func _find_by_id(node, id: String):
+	if node is Control and (node as Control).name == id:
+		return node
+	for child in node.get_children():
+		var r = _find_by_id(child, id)
+		if r != null:
+			return r
+	return null
+
+
+func test_transform_scale_applied_to_control() -> void:
+	var view := _build_view_with(
+		'<div id="box" style="">box</div>',
+		'#box { width: 100px; height: 100px; transform: scale(1.5); }'
+	)
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	var box: Control = view.get_element_by_id("box")
+	assert_not_null(box)
+	assert_eq(box.scale, Vector2(1.5, 1.5))
+
+
+func test_transform_rotate_applied_to_control() -> void:
+	var view := _build_view_with(
+		'<div id="box">box</div>',
+		'#box { width: 100px; height: 100px; transform: rotate(90deg); }'
+	)
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	var box: Control = view.get_element_by_id("box")
+	assert_not_null(box)
+	assert_almost_eq(box.rotation, PI / 2.0, 0.001)
+#endregion

--- a/tests/unit/test_transforms.gd.uid
+++ b/tests/unit/test_transforms.gd.uid
@@ -1,0 +1,1 @@
+uid://qhfq5mx2hgcb

--- a/tests/unit/test_v04_review_fixups.gd
+++ b/tests/unit/test_v04_review_fixups.gd
@@ -1,0 +1,194 @@
+extends GutTest
+
+## Tests for the v0.4 pre-PR review fixups:
+##   - var() cycle detection (no hang on --a: var(--a) or chains)
+##   - unterminated var() emits warning + does not crash
+##   - typo'd pseudo (e.g. :chekced) drops the rule even alone
+##   - radio without `name` is dropped from get_form_data silently
+##   - calc() division by zero warns + produces no NaN/Inf in style
+##   - submit button outside <form> still fires form_submitted (documented)
+##   - HTML parser get_warnings() exposes line/col/msg (already in
+##     test_parser_robustness, not repeated here)
+
+const GmlHtmlParserScript = preload("res://addons/gtml/src/html_parser/GmlHtmlParser.gd")
+const GmlCssParserScript = preload("res://addons/gtml/src/css/GmlCssParser.gd")
+const GmlStyleResolverScript = preload("res://addons/gtml/src/css/GmlStyleResolver.gd")
+const GmlCssEvalScript = preload("res://addons/gtml/src/css/GmlCssEval.gd")
+const GmlViewScript = preload("res://addons/gtml/src/GmlView.gd")
+
+
+func _style_for_id(html: String, css: String, id: String) -> Dictionary:
+	var dom = GmlHtmlParserScript.new().parse(html)
+	var rules := GmlCssParserScript.new().parse(css)
+	var styles: Dictionary = GmlStyleResolverScript.new().resolve(dom, rules)
+	var node = _find_by_id(dom, id)
+	if node == null:
+		return {}
+	return styles.get(node, {})
+
+
+func _find_by_id(node, id: String):
+	if node == null or node.is_text_node:
+		return null
+	if node.get_id() == id:
+		return node
+	for c in node.children:
+		var r = _find_by_id(c, id)
+		if r != null:
+			return r
+	return null
+
+
+#region var() edge cases
+
+
+func test_var_self_cycle_does_not_hang() -> void:
+	# --a: var(--a); — direct self-reference must not infinite-recurse.
+	# Enforce with a wall-clock budget.
+	var t0 := Time.get_ticks_msec()
+	var s := _style_for_id(
+		"<p id='target'>x</p>",
+		"p { --a: var(--a); color: var(--a); }",
+		"target")
+	var dt := Time.get_ticks_msec() - t0
+	assert_true(dt < 500, "var cycle took %dms — expected <500" % dt)
+
+
+func test_var_two_key_cycle_does_not_hang() -> void:
+	# --a -> --b -> --a must also break cleanly.
+	var t0 := Time.get_ticks_msec()
+	var s := _style_for_id(
+		"<p id='target'>x</p>",
+		"p { --a: var(--b); --b: var(--a); color: var(--a); }",
+		"target")
+	var dt := Time.get_ticks_msec() - t0
+	assert_true(dt < 500, "two-key var cycle took %dms — expected <500" % dt)
+
+
+func test_unterminated_var_does_not_crash() -> void:
+	# var( with no closing paren — substitute_vars must terminate.
+	var out: String = GmlCssEvalScript.substitute_vars("color: var(--x", {})
+	# Either resolves with what we have, or returns the original tail.
+	# The contract: it returns *something* without hanging or erroring out.
+	assert_true(out is String)
+
+
+#endregion
+
+
+#region pseudo typos
+
+
+func test_typoed_pseudo_alone_drops_rule() -> void:
+	# Direct typo without any valid pseudo to mask it — must not silently
+	# leak into the base style or any bucket.
+	var s := _style_for_id(
+		"<button id='target'>x</button>",
+		"button:chekced { color: red; }",
+		"target")
+	for key in s.keys():
+		if str(key).begins_with("_") and "chekced" in str(key):
+			fail_test("typo'd pseudo bucket leaked into output: %s" % key)
+	assert_false(s.get("color") == Color.RED, "typo'd pseudo must not apply to base style")
+
+
+#endregion
+
+
+#region calc()
+
+
+func test_calc_division_by_zero_warns_and_recovers() -> void:
+	# calc(10 / 0) — _combine bails by returning the lhs operand, so the
+	# resolved value is just "10" and the type parser produces a finite int.
+	var s := _style_for_id(
+		"<div id='target'>x</div>",
+		"div { padding: calc(10 / 0); }",
+		"target")
+	var v = s.get("padding")
+	assert_not_null(v, "calc by zero should still produce SOME value, got null")
+	if v is float:
+		assert_false(is_inf(v), "calc by zero must not yield Inf")
+		assert_false(is_nan(v), "calc by zero must not yield NaN")
+	else:
+		assert_true(v is int, "calc by zero recovery should yield an int, got %s" % typeof(v))
+
+
+#endregion
+
+
+#region form data
+
+
+func _build_view(html: String) -> GmlView:
+	var dir := "res://tests/snapshots/.actual/v04_fixups_fixture"
+	var html_path := dir + "/index.html"
+	var css_path := dir + "/style.css"
+	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(dir))
+	var fh := FileAccess.open(html_path, FileAccess.WRITE)
+	fh.store_string(html)
+	fh.close()
+	var fc := FileAccess.open(css_path, FileAccess.WRITE)
+	fc.store_string("")
+	fc.close()
+
+	var view: GmlView = GmlViewScript.new()
+	view.html_path = html_path
+	view.css_path = css_path
+	view.size = Vector2(300, 200)
+	add_child_autofree(view)
+	return view
+
+
+func test_radio_without_name_falls_back_to_checkbox_semantics() -> void:
+	# Pin the documented quirk: a radio with no `name` has no ButtonGroup,
+	# so get_form_data() can't distinguish it from a CheckBox and collects
+	# it under its id as a bool. Authoring error on the user's side — name
+	# is required for radios — but collection of OTHER inputs still works.
+	var view := _build_view(
+		'<form><input id="a" type="radio"><input id="b" type="text" value="hi"></form>'
+	)
+	await get_tree().process_frame
+	await get_tree().process_frame
+	var data: Dictionary = view.get_form_data()
+	# The groupless radio is collected as a bool (CheckBox semantics).
+	assert_true(data.has("a"), "groupless radio falls back to checkbox semantics")
+	assert_true(data.get("a") is bool, "groupless radio value should be a bool, got %s" % typeof(data.get("a")))
+	# And the other input is still collected normally.
+	assert_eq(data.get("b"), "hi")
+
+
+func test_submit_outside_form_still_emits_form_submitted() -> void:
+	# Documented behavior — GTML has no <form> scoping, so a bare submit
+	# fires form_submitted with the whole view's input snapshot.
+	var view := _build_view(
+		'<div>'
+		+ '<input id="title" type="text" value="hi">'
+		+ '<input type="submit" value="Go">'
+		+ '</div>'
+	)
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	var emitted := []
+	view.form_submitted.connect(func(data: Dictionary):
+		emitted.append(data)
+	)
+	var btn: Button = _find_button(view, "Go")
+	assert_not_null(btn)
+	btn.pressed.emit()
+	assert_eq(emitted.size(), 1)
+	assert_eq(emitted[0].get("title"), "hi")
+
+
+func _find_button(node: Node, label: String):
+	if node is Button and (node as Button).text == label:
+		return node
+	for child in node.get_children():
+		var r = _find_button(child, label)
+		if r != null:
+			return r
+	return null
+
+
+#endregion


### PR DESCRIPTION
## Summary

Four themes bundled per the design discussion: CSS authoring tokens, CSS visuals, form interactivity, editor DX. 8 commits, **151/151 tests green**. Breaking changes: none; everything is additive.

## What's in

| Theme | Features |
|---|---|
| **CSS tokens** | `--name` custom properties, `var(--name, fallback)` with cycle detection, `calc()` arithmetic (`+ - * /`) with unit rules |
| **CSS visuals** | `:checked` pseudo-class on CheckBox + radio (themed via CSS-driven `pressed` stylebox), CSS `transform` (translate/scale/rotate, compose left-to-right, pivot at center) |
| **Interactivity** | `GmlView.get_form_data()` collects every registered input; submit buttons fire `form_submitted` with the snapshot; new `@keydown` attribute + `key_pressed` signal |
| **Editor DX** | Inline parse-warnings overlay (HTML + CSS) with click-to-jump-to-line, FileSystem-signal hot reload alongside the per-frame fallback poll |

## Stats

| | |
|---|---|
| Tests | 151 (was 119) |
| New modules | `GmlCssEval`, `GmlTransformValues` |
| New signals | `key_pressed` |
| Plugin version | 0.3.1 → 0.4.0 |

## Limitations / deferred (in CHANGELOG)

- `transform` does not yet interpolate through transitions (no animated hover-scale yet)
- `calc()` doesn't support mixed-unit subtraction like `calc(100% - 20px)`
- `--*` inside a state bucket isn't added to bucket-local scope
- GTML has no `<form>` scoping — a stray submit collects the whole view's inputs
- Radio without `name` falls back to CheckBox semantics (collect-as-bool under id)

## Test plan

- [ ] `godot --headless -s addons/gut/gut_cmdln.gd -gconfig=res://.gutconfig.json` → 151/151 green
- [ ] Add `--brand: #9b7eff;` to Forge `style.css` `.app` selector and replace one hardcoded color with `var(--brand)` — preview reflects the change
- [ ] Wrap a Forge button class with `transform: scale(1.5)` to confirm transforms render
- [ ] Click a checkbox row in Forge and confirm `:checked` stylebox applies if you add `.check-box:checked { background-color: ...; }`
- [ ] In the editor, save HTML with a deliberate typo (e.g. `<div></ddiv>`) and confirm the inline warnings panel shows a click-to-jump entry