### PR TITLE
v0.5: transform transitions + showcase polish + kitchen-sink + docs refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## 0.5.0
+
+### Features
+
+- **`transform` is now animated through the transition manager**. Including
+  `transform` in a `transition:` declaration interpolates scale, rotation,
+  and the layout-relative position offset together through a single tween.
+  Absent target transforms revert to the identity, so `:hover` → no-hover
+  animates back to neutral without an explicit reverse rule.
+- **Kitchen-sink showcase sample** at `addons/gtml/examples/showcase/kitchen/`
+  exercises virtually every supported element + CSS property in one scene.
+  Useful as both a feature reference card and a regression smoke test.
+- **CSS property names accept digits** (`--surface-2`, `--gap-1`). The
+  parser previously truncated at the first digit, which broke
+  numerically-suffixed token names.
+
+### Polish
+
+- All three v0.3.1 showcase scenes refactored:
+  - Palettes extracted to top-level `--*` custom properties
+  - `transform: scale(...)` on hover for KPI cards (atlas) + primary
+    buttons (atlas/forge) + a 2px translate on Atelier's related-article
+    links
+  - `:checked` styling on Forge's checkbox + radio rows fills with the
+    accent color when toggled on
+
+### Docs
+
+- New pages: `docs/css-tokens.md`, `docs/transforms.md`
+- Updated: `docs/css-selectors.md` (combinators, attribute matchers,
+  structural pseudos, multi-pseudo), `docs/forms-and-inputs.md`
+  (form value collection, `@keydown`, `<label for>`, `:checked` / `:focus`
+  styleboxes), `docs/transitions.md` (transform interpolation +
+  transparent→opaque flash workaround), `docs/getting-started.md`,
+  `docs/limitations.md` (rewrites the now-resolved sections)
+
+
 ## 0.4.0
 
 ### Features

--- a/addons/gtml/examples/showcase/atelier/style.css
+++ b/addons/gtml/examples/showcase/atelier/style.css
@@ -5,12 +5,24 @@
  */
 
 .page {
+    --bg: #f5f0e8;
+    --bg-sidebar: #ebe3d4;
+    --bg-deep: #e0d8c8;
+    --bg-hover: #ddd3c0;
+    --border-1: #d8cfc0;
+    --border-2: #c4b8a4;
+    --text-strong: #1a1612;
+    --text-body: #2a2218;
+    --text-2: #4a4035;
+    --text-muted: #6e6457;
+    --accent: #a8451f;
+
     display: flex;
     flex-direction: column;
     width: 100%;
     height: 100%;
-    background-color: #f5f0e8;
-    color: #1a1612;
+    background-color: var(--bg);
+    color: var(--text-strong);
 }
 
 /* ─── Masthead ──────────────────────────────────────── */
@@ -24,7 +36,7 @@
     padding-right: 48px;
     padding-top: 24px;
     padding-bottom: 24px;
-    border-bottom: 1px solid #d8cfc0;
+    border-bottom: 1px solid var(--border-1);
 }
 
 .masthead-left {
@@ -36,14 +48,14 @@
 
 .logo {
     font-size: 18px;
-    color: #1a1612;
+    color: var(--text-strong);
     font-weight: 700;
     letter-spacing: 6;
 }
 
 .tagline {
     font-size: 11px;
-    color: #6e6457;
+    color: var(--text-muted);
     letter-spacing: 2;
     text-transform: uppercase;
     font-weight: 500;
@@ -57,7 +69,7 @@
 
 .issue {
     font-size: 11px;
-    color: #a8451f;
+    color: var(--accent);
     letter-spacing: 3;
     font-weight: 600;
 }
@@ -95,26 +107,26 @@
 
 .essay-section {
     font-size: 11px;
-    color: #a8451f;
+    color: var(--accent);
     letter-spacing: 4;
     font-weight: 700;
 }
 
 .essay-dot {
-    color: #c4b8a4;
+    color: var(--border-2);
     font-size: 12px;
 }
 
 .essay-kind {
     font-size: 11px;
-    color: #6e6457;
+    color: var(--text-muted);
     letter-spacing: 4;
     font-weight: 600;
 }
 
 .essay-title {
     font-size: 48px;
-    color: #1a1612;
+    color: var(--text-strong);
     font-weight: 700;
     line-height: 4;
     margin-bottom: 8px;
@@ -122,7 +134,7 @@
 
 .essay-deck {
     font-size: 18px;
-    color: #4a4035;
+    color: var(--text-2);
     line-height: 8;
     font-weight: 400;
     margin-bottom: 16px;
@@ -134,31 +146,31 @@
     align-items: center;
     gap: 8px;
     padding-bottom: 24px;
-    border-bottom: 1px solid #d8cfc0;
+    border-bottom: 1px solid var(--border-1);
     margin-bottom: 16px;
 }
 
 .byline-name {
     font-size: 12px;
-    color: #1a1612;
+    color: var(--text-strong);
     font-weight: 600;
     letter-spacing: 1;
 }
 
 .byline-sep {
-    color: #c4b8a4;
+    color: var(--border-2);
     font-size: 11px;
 }
 
 .byline-time {
     font-size: 11px;
-    color: #6e6457;
+    color: var(--text-muted);
     letter-spacing: 1;
 }
 
 .byline-date {
     font-size: 11px;
-    color: #6e6457;
+    color: var(--text-muted);
     letter-spacing: 1;
 }
 
@@ -170,26 +182,26 @@
 
 .lead {
     font-size: 17px;
-    color: #2a2218;
+    color: var(--text-body);
     line-height: 9;
     font-weight: 500;
 }
 
 .essay-body p {
     font-size: 15px;
-    color: #2a2218;
+    color: var(--text-body);
     line-height: 10;
 }
 
 .callout {
     font-size: 20px;
-    color: #a8451f;
+    color: var(--accent);
     font-weight: 600;
     line-height: 6;
     padding-top: 16px;
     padding-bottom: 16px;
     padding-left: 24px;
-    border-left: 3px solid #a8451f;
+    border-left: 3px solid var(--accent);
     margin-top: 16px;
     margin-bottom: 16px;
 }
@@ -200,13 +212,13 @@
     display: flex;
     flex-direction: column;
     width: 280px;
-    background-color: #ebe3d4;
+    background-color: var(--bg-sidebar);
     padding-left: 32px;
     padding-right: 32px;
     padding-top: 56px;
     padding-bottom: 56px;
     gap: 40px;
-    border-left: 1px solid #d8cfc0;
+    border-left: 1px solid var(--border-1);
     /* Sidebar content can exceed viewport height — scroll independently of
        the essay column so neither falls off the bottom. */
     overflow-y: auto;
@@ -220,11 +232,11 @@
 
 .side-heading {
     font-size: 11px;
-    color: #6e6457;
+    color: var(--text-muted);
     letter-spacing: 4;
     font-weight: 700;
     padding-bottom: 8px;
-    border-bottom: 1px solid #c4b8a4;
+    border-bottom: 1px solid var(--border-2);
     margin-bottom: 4px;
 }
 
@@ -237,54 +249,57 @@
 
 .side-item {
     font-size: 13px;
-    color: #2a2218;
+    color: var(--text-body);
     padding-top: 8px;
     padding-bottom: 8px;
     padding-left: 12px;
     padding-right: 12px;
     border-radius: 2px;
     /* Opaque base matches the sidebar so hover interpolates clean. */
-    background-color: #ebe3d4;
+    background-color: var(--bg-sidebar);
     transition: background-color 180ms, color 180ms;
 }
 
 .side-item:hover {
-    background-color: #ddd3c0;
+    background-color: var(--bg-hover);
 }
 
 .side-active {
-    color: #a8451f;
+    color: var(--accent);
     font-weight: 600;
-    border-left: 2px solid #a8451f;
+    border-left: 2px solid var(--accent);
     padding-left: 10px;
 }
 
 .side-item-link {
     font-size: 13px;
-    color: #4a4035;
+    color: var(--text-2);
     padding-top: 8px;
     padding-bottom: 8px;
     padding-left: 12px;
     padding-right: 12px;
     border-radius: 2px;
-    background-color: #ebe3d4;
-    border-bottom: 1px solid #ddd3c0;
-    transition: color 180ms, border-bottom 180ms;
+    background-color: var(--bg-sidebar);
+    border-bottom: 1px solid var(--bg-hover);
+    transition: color 180ms, border-bottom 180ms, transform 220ms;
 }
 
 .side-item-link:hover {
-    color: #a8451f;
-    border-bottom: 1px solid #a8451f;
+    color: var(--accent);
+    border-bottom: 1px solid var(--accent);
+    /* Editorial flair: a 2px push on hover, like the cursor arrow next
+       to a print article. Subtle, intentional, not a bounce. */
+    transform: translate(2px, 0);
 }
 
 .side-block-quiet {
-    background-color: #e0d8c8;
+    background-color: var(--bg-deep);
     padding: 20px;
     border-radius: 2px;
 }
 
 .side-note {
     font-size: 12px;
-    color: #4a4035;
+    color: var(--text-2);
     line-height: 8;
 }

--- a/addons/gtml/examples/showcase/atlas/style.css
+++ b/addons/gtml/examples/showcase/atlas/style.css
@@ -1,15 +1,33 @@
 /* Atlas — mission-control dashboard
  * Precision + density. Cool slate neutrals. Single cyan accent reserved for
  * live signal and primary action. Borders only, no shadows. 8/16/24 grid.
+ *
+ * Palette is declared once on .app as CSS custom properties; descendants
+ * read them via var(). Authors can re-brand the entire surface by editing
+ * the block below.
  */
 
 .app {
+    --bg: #0a0e1a;
+    --surface-1: #0c1120;
+    --surface-2: #0e1322;
+    --border-1: #1a2236;
+    --border-2: #1f2a3f;
+    --text-1: #c8cfdd;
+    --text-2: #8a93a8;
+    --text-3: #6c7691;
+    --text-4: #5a6480;
+    --accent: #5fc8ff;
+    --accent-hot: #8edaff;
+    --success: #6dd198;
+    --warn: #ffb454;
+
     display: flex;
     flex-direction: column;
     width: 100%;
     height: 100%;
-    background-color: #0a0e1a;
-    color: #c8cfdd;
+    background-color: var(--bg);
+    color: var(--text-1);
 }
 
 /* ─── Topbar ────────────────────────────────────────── */
@@ -23,8 +41,8 @@
     padding-right: 24px;
     padding-top: 14px;
     padding-bottom: 14px;
-    border-bottom: 1px solid #1a2236;
-    background-color: #0c1120;
+    border-bottom: 1px solid var(--border-1);
+    background-color: var(--surface-1);
 }
 
 .brand-block {
@@ -49,7 +67,7 @@
 
 .brand-context {
     font-size: 13px;
-    color: #8a93a8;
+    color: var(--text-2);
     letter-spacing: 1;
 }
 
@@ -69,21 +87,21 @@
     padding-right: 12px;
     padding-top: 6px;
     padding-bottom: 6px;
-    border: 1px solid #1f3045;
+    border: 1px solid var(--border-2);
     border-radius: 999px;
-    background-color: #0e1828;
+    background-color: var(--surface-2);
 }
 
 .status-dot {
     width: 6px;
     height: 6px;
     border-radius: 3px;
-    background-color: #5fc8ff;
+    background-color: var(--accent);
 }
 
 .status-label {
     font-size: 12px;
-    color: #5fc8ff;
+    color: var(--accent);
     letter-spacing: 1;
     text-transform: uppercase;
     font-weight: 600;
@@ -91,12 +109,12 @@
 
 .user-chip {
     font-size: 12px;
-    color: #8a93a8;
+    color: var(--text-2);
     padding-left: 10px;
     padding-right: 10px;
     padding-top: 6px;
     padding-bottom: 6px;
-    border: 1px solid #1f2a3f;
+    border: 1px solid var(--border-2);
     border-radius: 4px;
     letter-spacing: 1;
 }
@@ -116,8 +134,8 @@
     display: flex;
     flex-direction: column;
     width: 224px;
-    background-color: #0c1120;
-    border-right: 1px solid #1a2236;
+    background-color: var(--surface-1);
+    border-right: 1px solid var(--border-1);
     padding: 16px;
     gap: 24px;
 }
@@ -130,7 +148,7 @@
 
 .nav-label {
     font-size: 11px;
-    color: #4a5670;
+    color: var(--text-4);
     letter-spacing: 1;
     text-transform: uppercase;
     font-weight: 600;
@@ -141,7 +159,7 @@
 .nav-item {
     display: block;
     font-size: 13px;
-    color: #8a93a8;
+    color: var(--text-2);
     padding-left: 12px;
     padding-right: 12px;
     padding-top: 8px;
@@ -149,19 +167,19 @@
     border-radius: 4px;
     /* Match the sidebar surface so hover interpolates between opaque colors
        only — transparent->opaque produces a gray "alpha flash" mid-transition. */
-    background-color: #0c1120;
+    background-color: var(--surface-1);
     transition: background-color 150ms, color 150ms;
 }
 
 .nav-item:hover {
     background-color: #131a2e;
-    color: #c8cfdd;
+    color: var(--text-1);
 }
 
 .nav-active {
     background-color: #131a2e;
     color: #ffffff;
-    border-left: 2px solid #5fc8ff;
+    border-left: 2px solid var(--accent);
     padding-left: 10px;
 }
 
@@ -192,7 +210,7 @@
 
 .eyebrow {
     font-size: 11px;
-    color: #5fc8ff;
+    color: var(--accent);
     letter-spacing: 3;
     text-transform: uppercase;
     font-weight: 600;
@@ -206,12 +224,12 @@
 
 .page-subtitle {
     font-size: 13px;
-    color: #6c7691;
+    color: var(--text-3);
 }
 
 .primary-action {
-    background-color: #5fc8ff;
-    color: #0a0e1a;
+    background-color: var(--accent);
+    color: var(--bg);
     border: none;
     border-radius: 4px;
     padding-left: 16px;
@@ -222,11 +240,12 @@
     font-weight: 600;
     letter-spacing: 1;
     text-transform: uppercase;
-    transition: background-color 180ms;
+    transition: background-color 180ms, transform 180ms;
 }
 
 .primary-action:hover {
-    background-color: #8edaff;
+    background-color: var(--accent-hot);
+    transform: scale(1.03);
 }
 
 /* ─── KPI row ───────────────────────────────────────── */
@@ -243,14 +262,20 @@
     flex-grow: 1;
     gap: 8px;
     padding: 20px;
-    border: 1px solid #1a2236;
+    border: 1px solid var(--border-1);
     border-radius: 6px;
-    background-color: #0e1322;
+    background-color: var(--surface-2);
+    transition: border 220ms, transform 220ms;
+}
+
+.kpi:hover {
+    border: 1px solid var(--border-2);
+    transform: scale(1.015);
 }
 
 .kpi-label {
     font-size: 11px;
-    color: #6c7691;
+    color: var(--text-3);
     letter-spacing: 2;
     text-transform: uppercase;
     font-weight: 600;
@@ -263,25 +288,25 @@
 }
 
 .kpi-warn {
-    color: #ffb454;
+    color: var(--warn);
 }
 
 .kpi-delta {
     font-size: 11px;
-    color: #5a6480;
+    color: var(--text-4);
     letter-spacing: 1;
 }
 
 .delta-up {
-    color: #6dd198;
+    color: var(--success);
 }
 
 .delta-down {
-    color: #5fc8ff;
+    color: var(--accent);
 }
 
 .delta-flat {
-    color: #5a6480;
+    color: var(--text-4);
 }
 
 /* ─── Card grid ─────────────────────────────────────── */
@@ -296,9 +321,9 @@
     display: flex;
     flex-direction: column;
     flex-grow: 1;
-    border: 1px solid #1a2236;
+    border: 1px solid var(--border-1);
     border-radius: 6px;
-    background-color: #0e1322;
+    background-color: var(--surface-2);
 }
 
 .card-head {
@@ -307,7 +332,7 @@
     justify-content: space-between;
     align-items: center;
     padding: 20px;
-    border-bottom: 1px solid #1a2236;
+    border-bottom: 1px solid var(--border-1);
 }
 
 .card-title {
@@ -318,7 +343,7 @@
 
 .card-meta {
     font-size: 11px;
-    color: #5a6480;
+    color: var(--text-4);
     letter-spacing: 2;
     text-transform: uppercase;
 }
@@ -342,7 +367,7 @@
     border-radius: 4px;
     /* Opaque base color so the hover transition doesn't pass through an
        alpha-blended intermediate. Matches the surrounding card surface. */
-    background-color: #0e1322;
+    background-color: var(--surface-2);
     transition: background-color 150ms;
 }
 
@@ -352,7 +377,7 @@
 
 .activity-time {
     font-size: 12px;
-    color: #5a6480;
+    color: var(--text-4);
     letter-spacing: 1;
     min-width: 44px;
     font-weight: 600;
@@ -360,7 +385,7 @@
 
 .activity-text {
     font-size: 13px;
-    color: #c8cfdd;
+    color: var(--text-1);
 }
 
 /* ─── Status list ───────────────────────────────────── */
@@ -391,7 +416,7 @@
 
 .status-name {
     font-size: 13px;
-    color: #c8cfdd;
+    color: var(--text-1);
 }
 
 .status-badge {
@@ -407,12 +432,12 @@
 
 .badge-ok {
     background-color: #112d22;
-    color: #6dd198;
+    color: var(--success);
     border: 1px solid #1f4836;
 }
 
 .badge-warn {
     background-color: #2d2418;
-    color: #ffb454;
+    color: var(--warn);
     border: 1px solid #4d3c1f;
 }

--- a/addons/gtml/examples/showcase/forge/style.css
+++ b/addons/gtml/examples/showcase/forge/style.css
@@ -5,12 +5,33 @@
  */
 
 .app {
+    --bg: #0d0d0d;
+    --surface-1: #111111;
+    --surface-2: #131313;
+    --surface-2-hover: #181818;
+    --surface-input: #161616;
+    --surface-input-hover: #1a1a1a;
+    --surface-active: #1f1a2e;
+    --surface-focus: #1a1525;
+    --border-1: #1f1f1f;
+    --border-2: #2a2a2a;
+    --border-3: #3a3a3a;
+    --text-faint: #5a5a5a;
+    --text-muted: #6a6a6a;
+    --text-2: #8a8a8a;
+    --text-1: #b8b8b8;
+    --text-strong: #d4d4d4;
+    --accent: #9b7eff;
+    --accent-hot: #b39dff;
+    --accent-faint: #d4c8ff;
+    --accent-text: #b39dff;
+
     display: flex;
     flex-direction: column;
     width: 100%;
     height: 100%;
-    background-color: #0d0d0d;
-    color: #d4d4d4;
+    background-color: var(--bg);
+    color: var(--text-strong);
 }
 
 /* ─── Topbar ────────────────────────────────────────── */
@@ -24,8 +45,8 @@
     padding-right: 24px;
     padding-top: 14px;
     padding-bottom: 14px;
-    border-bottom: 1px solid #1f1f1f;
-    background-color: #111111;
+    border-bottom: 1px solid var(--border-1);
+    background-color: var(--surface-1);
 }
 
 .topbar-left {
@@ -43,13 +64,13 @@
 }
 
 .brand-divider {
-    color: #3a3a3a;
+    color: var(--border-3);
     font-size: 14px;
 }
 
 .crumb {
     font-size: 13px;
-    color: #8a8a8a;
+    color: var(--text-2);
 }
 
 .topbar-actions {
@@ -60,7 +81,7 @@
 }
 
 .btn {
-    border: 1px solid #2a2a2a;
+    border: 1px solid var(--border-2);
     border-radius: 4px;
     padding-left: 14px;
     padding-right: 14px;
@@ -73,28 +94,30 @@
 
 .btn-ghost {
     /* Match the topbar surface so hover interpolates opaque->opaque. */
-    background-color: #111111;
-    color: #d4d4d4;
+    background-color: var(--surface-1);
+    color: var(--text-strong);
 }
 
 .btn-ghost:hover {
-    background-color: #1a1a1a;
-    border: 1px solid #3a3a3a;
+    background-color: var(--surface-input-hover);
+    border: 1px solid var(--border-3);
 }
 
 .btn-primary {
-    background-color: #9b7eff;
-    color: #0d0d0d;
-    border: 1px solid #9b7eff;
+    background-color: var(--accent);
+    color: var(--bg);
+    border: 1px solid var(--accent);
+    transition: background-color 180ms, border 180ms, color 180ms, transform 180ms;
 }
 
 .btn-primary:hover {
-    background-color: #b39dff;
-    border: 1px solid #b39dff;
+    background-color: var(--accent-hot);
+    border: 1px solid var(--accent-hot);
+    transform: scale(1.03);
 }
 
 .btn-primary:focus {
-    border: 1px solid #d4c8ff;
+    border: 1px solid var(--accent-faint);
 }
 
 /* ─── Shell ──────────────────────────────────────────── */
@@ -112,8 +135,8 @@
     display: flex;
     flex-direction: column;
     width: 220px;
-    background-color: #111111;
-    border-right: 1px solid #1f1f1f;
+    background-color: var(--surface-1);
+    border-right: 1px solid var(--border-1);
     padding: 16px;
     gap: 24px;
 }
@@ -126,7 +149,7 @@
 
 .nav-group-label {
     font-size: 10px;
-    color: #5a5a5a;
+    color: var(--text-faint);
     letter-spacing: 3;
     text-transform: uppercase;
     font-weight: 700;
@@ -137,26 +160,26 @@
 .nav-link {
     display: block;
     font-size: 13px;
-    color: #8a8a8a;
+    color: var(--text-2);
     padding-left: 12px;
     padding-right: 12px;
     padding-top: 7px;
     padding-bottom: 7px;
     border-radius: 4px;
     /* Match the sidenav surface so hover doesn't flash through alpha. */
-    background-color: #111111;
+    background-color: var(--surface-1);
     transition: background-color 150ms, color 150ms;
 }
 
 .nav-link:hover {
-    background-color: #1a1a1a;
-    color: #d4d4d4;
+    background-color: var(--surface-input-hover);
+    color: var(--text-strong);
 }
 
 .nav-link-active {
-    background-color: #1f1a2e;
-    color: #b39dff;
-    border-left: 2px solid #9b7eff;
+    background-color: var(--surface-active);
+    color: var(--accent-hot);
+    border-left: 2px solid var(--accent);
     padding-left: 10px;
     font-weight: 600;
 }
@@ -178,7 +201,7 @@
 
 .section-divider {
     height: 1px;
-    background-color: #1f1f1f;
+    background-color: var(--border-1);
 }
 
 .form-section {
@@ -203,7 +226,7 @@
 
 .section-help {
     font-size: 13px;
-    color: #6a6a6a;
+    color: var(--text-muted);
 }
 
 /* ─── Field ──────────────────────────────────────────── */
@@ -216,15 +239,15 @@
 
 .field-label {
     font-size: 12px;
-    color: #b8b8b8;
+    color: var(--text-1);
     font-weight: 600;
     letter-spacing: 1;
 }
 
 .field-input {
-    background-color: #161616;
+    background-color: var(--surface-input);
     color: #ffffff;
-    border: 1px solid #2a2a2a;
+    border: 1px solid var(--border-2);
     border-radius: 4px;
     padding-left: 12px;
     padding-right: 12px;
@@ -235,18 +258,18 @@
 }
 
 .field-input:hover {
-    background-color: #1a1a1a;
-    border: 1px solid #3a3a3a;
+    background-color: var(--surface-input-hover);
+    border: 1px solid var(--border-3);
 }
 
 .field-input:focus {
-    background-color: #1a1525;
-    border: 1px solid #9b7eff;
+    background-color: var(--surface-focus);
+    border: 1px solid var(--accent);
 }
 
 .field-hint {
     font-size: 12px;
-    color: #5a5a5a;
+    color: var(--text-faint);
 }
 
 /* ─── Checkbox row ───────────────────────────────────── */
@@ -257,15 +280,15 @@
     align-items: flex-start;
     gap: 12px;
     padding: 12px;
-    border: 1px solid #1f1f1f;
+    border: 1px solid var(--border-1);
     border-radius: 4px;
-    background-color: #131313;
+    background-color: var(--surface-2);
     transition: background-color 150ms, border 150ms;
 }
 
 .check-row:hover {
-    background-color: #181818;
-    border: 1px solid #2a2a2a;
+    background-color: var(--surface-2-hover);
+    border: 1px solid var(--border-2);
 }
 
 .check-box {
@@ -274,7 +297,13 @@
 }
 
 .check-box:focus {
-    border: 1px solid #9b7eff;
+    border: 1px solid var(--accent);
+    border-radius: 3px;
+}
+
+.check-box:checked {
+    background-color: var(--accent);
+    border: 1px solid var(--accent-hot);
     border-radius: 3px;
 }
 
@@ -292,7 +321,7 @@
 
 .check-help {
     font-size: 12px;
-    color: #6a6a6a;
+    color: var(--text-muted);
 }
 
 /* ─── Radio row ──────────────────────────────────────── */
@@ -303,15 +332,15 @@
     align-items: flex-start;
     gap: 12px;
     padding: 12px;
-    border: 1px solid #1f1f1f;
+    border: 1px solid var(--border-1);
     border-radius: 4px;
-    background-color: #131313;
+    background-color: var(--surface-2);
     transition: background-color 150ms, border 150ms;
 }
 
 .radio-row:hover {
-    background-color: #181818;
-    border: 1px solid #2a2a2a;
+    background-color: var(--surface-2-hover);
+    border: 1px solid var(--border-2);
 }
 
 .radio-dot {
@@ -320,7 +349,13 @@
 }
 
 .radio-dot:focus {
-    border: 1px solid #9b7eff;
+    border: 1px solid var(--accent);
+    border-radius: 9px;
+}
+
+.radio-dot:checked {
+    background-color: var(--accent);
+    border: 1px solid var(--accent-hot);
     border-radius: 9px;
 }
 
@@ -338,5 +373,5 @@
 
 .radio-help {
     font-size: 12px;
-    color: #6a6a6a;
+    color: var(--text-muted);
 }

--- a/addons/gtml/examples/showcase/kitchen/demo.tscn
+++ b/addons/gtml/examples/showcase/kitchen/demo.tscn
@@ -1,0 +1,31 @@
+[gd_scene load_steps=2 format=3 uid="uid://gml_kitchen_demo"]
+
+[ext_resource type="Script" path="res://addons/gtml/src/GmlView.gd" id="1_gmlview"]
+
+[node name="KitchenDemo" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Background" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.101, 0.113, 0.141, 1)
+
+[node name="GmlView" type="Control" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_gmlview")
+html_path = "res://addons/gtml/examples/showcase/kitchen/index.html"
+css_path = "res://addons/gtml/examples/showcase/kitchen/style.css"

--- a/addons/gtml/examples/showcase/kitchen/index.html
+++ b/addons/gtml/examples/showcase/kitchen/index.html
@@ -1,0 +1,121 @@
+<div class="page">
+
+  <header class="top">
+    <span class="brand">GTML</span>
+    <span class="brand-sep">·</span>
+    <span class="brand-context">kitchen sink</span>
+    <span class="brand-flex"></span>
+    <span class="version">v0.5</span>
+  </header>
+
+  <main class="sheet">
+
+    <!-- ─── Typography ─────────────────────────────────── -->
+    <section class="block">
+      <span class="block-eyebrow">01 · Typography</span>
+      <h1>Heading one</h1>
+      <h2>Heading two</h2>
+      <h3>Heading three</h3>
+      <h4>Heading four</h4>
+      <h5>Heading five</h5>
+      <h6>Heading six</h6>
+      <p>Plain paragraph. <strong>Bold text</strong> via &lt;strong&gt;. <em>Italic text</em> via &lt;em&gt;. A <a href="#" class="link">link</a> for good measure.</p>
+      <p class="muted">Muted secondary text. Useful for help copy and timestamps.</p>
+      <p class="spaced">Letter-spacing 3px via FontVariation (v0.3).</p>
+      <p class="upper">text-transform: uppercase</p>
+      <p class="indent">First-line indent simulated with metadata; visual rendering deferred.</p>
+    </section>
+
+    <!-- ─── Layout primitives ──────────────────────────── -->
+    <section class="block">
+      <span class="block-eyebrow">02 · Layout</span>
+      <div class="row-demo">
+        <div class="swatch swatch-1">flex 1</div>
+        <div class="swatch swatch-2">flex 1</div>
+        <div class="swatch swatch-3">flex 2</div>
+      </div>
+      <div class="col-demo">
+        <div class="cell">column gap 12</div>
+        <div class="cell">column gap 12</div>
+        <div class="cell">column gap 12</div>
+      </div>
+      <div class="rounded">border-radius + box-shadow target</div>
+      <div class="gradient">linear-gradient background</div>
+    </section>
+
+    <!-- ─── Inputs ─────────────────────────────────────── -->
+    <section class="block">
+      <span class="block-eyebrow">03 · Inputs</span>
+
+      <label class="row" for="k-text">
+        <span class="label-text">Text input</span>
+        <input id="k-text" class="input" type="text" value="hello">
+      </label>
+
+      <label class="row" for="k-pass">
+        <span class="label-text">Password</span>
+        <input id="k-pass" class="input" type="password" value="secret">
+      </label>
+
+      <label class="row" for="k-check">
+        <input id="k-check" class="check" type="checkbox" checked>
+        <span class="label-text">Checkbox (with :checked)</span>
+      </label>
+
+      <div class="radio-group">
+        <label class="row" for="k-r1">
+          <input id="k-r1" class="check" type="radio" name="kpick" value="a">
+          <span class="label-text">Radio one</span>
+        </label>
+        <label class="row" for="k-r2">
+          <input id="k-r2" class="check" type="radio" name="kpick" value="b" checked>
+          <span class="label-text">Radio two (selected)</span>
+        </label>
+      </div>
+
+      <button class="btn-secondary">Secondary button</button>
+      <button class="btn-primary">Primary action</button>
+    </section>
+
+    <!-- ─── Lists ──────────────────────────────────────── -->
+    <section class="block">
+      <span class="block-eyebrow">04 · Lists</span>
+      <ul class="list">
+        <li>Unordered first</li>
+        <li>Unordered second (hover me)</li>
+        <li>Unordered third</li>
+      </ul>
+      <ol class="list">
+        <li>Ordered first</li>
+        <li>Ordered second</li>
+        <li>Ordered third</li>
+      </ol>
+    </section>
+
+    <!-- ─── Selectors + states ─────────────────────────── -->
+    <section class="block">
+      <span class="block-eyebrow">05 · Pseudos &amp; states</span>
+      <div class="state-grid">
+        <div class="state-card">:hover scales 1.04</div>
+        <button class="state-card focus-demo">tab here for :focus</button>
+        <div class="state-card combined">:hover + :focus combined</div>
+      </div>
+    </section>
+
+    <!-- ─── CSS features ───────────────────────────────── -->
+    <section class="block">
+      <span class="block-eyebrow">06 · CSS authoring</span>
+      <p class="feat-note">All three samples in this showcase use the features below:</p>
+      <ul class="feat-list">
+        <li><code>--name</code> custom properties + <code>var(--name)</code></li>
+        <li><code>calc()</code> for derived dimensions</li>
+        <li><code>transform: scale / translate / rotate</code> animated via transitions</li>
+        <li>Structural selectors: <code>:first-child</code>, <code>:nth-child(2n+1)</code>, <code>:not(...)</code></li>
+        <li>Substring attribute matchers: <code>[href^="https"]</code>, <code>[class~="card"]</code></li>
+        <li>Sibling combinators: <code>.a + .b</code>, <code>.a ~ .b</code></li>
+      </ul>
+    </section>
+
+  </main>
+
+</div>

--- a/addons/gtml/examples/showcase/kitchen/style.css
+++ b/addons/gtml/examples/showcase/kitchen/style.css
@@ -1,0 +1,361 @@
+/* Kitchen sink — reference card for every supported GTML feature.
+ * Quiet neutral palette so the showcased styles themselves carry the
+ * visual interest. Heavy use of v0.4 custom properties so the whole
+ * surface re-themes by editing the .page block. */
+
+.page {
+    --bg: #1a1d24;
+    --surface-1: #21252e;
+    --surface-2: #2a2f3a;
+    --border-1: #31374a;
+    --border-2: #41475a;
+    --text-1: #e0e3eb;
+    --text-2: #a3a8b8;
+    --text-muted: #6e7488;
+    --accent: #7dd3fc;
+    --accent-hot: #bae6fd;
+    --warm: #fbbf24;
+    --rose: #fb7185;
+    --gap-md: 14px;
+    --gap-lg: calc(var(--gap-md) * 2);
+
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    background-color: var(--bg);
+    color: var(--text-1);
+}
+
+.top {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 10px;
+    padding-left: 24px;
+    padding-right: 24px;
+    padding-top: 14px;
+    padding-bottom: 14px;
+    border-bottom: 1px solid var(--border-1);
+    background-color: var(--surface-1);
+}
+
+.brand {
+    font-size: 14px;
+    font-weight: 700;
+    letter-spacing: 2;
+    text-transform: uppercase;
+    color: var(--text-1);
+}
+
+.brand-sep { color: var(--text-muted); font-size: 14px; }
+.brand-context { font-size: 13px; color: var(--text-2); letter-spacing: 1; }
+.brand-flex { flex-grow: 1; }
+
+.version {
+    font-size: 11px;
+    color: var(--accent);
+    letter-spacing: 2;
+    font-weight: 700;
+    padding-left: 10px;
+    padding-right: 10px;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    border: 1px solid var(--border-2);
+    border-radius: 999px;
+}
+
+.sheet {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    padding: var(--gap-lg);
+    gap: var(--gap-lg);
+    overflow-y: auto;
+}
+
+/* ─── Block scaffolding ────────────────────────────── */
+
+.block {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 20px;
+    border: 1px solid var(--border-1);
+    border-radius: 6px;
+    background-color: var(--surface-1);
+}
+
+.block-eyebrow {
+    font-size: 10px;
+    color: var(--accent);
+    letter-spacing: 3;
+    font-weight: 700;
+    text-transform: uppercase;
+    padding-bottom: 6px;
+    border-bottom: 1px solid var(--border-1);
+    margin-bottom: 6px;
+}
+
+/* ─── Typography ───────────────────────────────────── */
+
+h1 { font-size: 32px; font-weight: 700; }
+h2 { font-size: 24px; font-weight: 700; }
+h3 { font-size: 20px; font-weight: 600; }
+h4 { font-size: 16px; font-weight: 600; color: var(--text-1); }
+h5 { font-size: 14px; font-weight: 600; color: var(--text-2); letter-spacing: 1; text-transform: uppercase; }
+h6 { font-size: 12px; font-weight: 600; color: var(--text-muted); letter-spacing: 2; text-transform: uppercase; }
+p  { font-size: 14px; color: var(--text-1); line-height: 4; }
+
+.muted   { color: var(--text-muted); }
+.spaced  { letter-spacing: 3; color: var(--text-2); }
+.upper   { text-transform: uppercase; letter-spacing: 2; color: var(--accent); font-weight: 600; font-size: 12px; }
+.indent  { text-indent: 16; color: var(--text-2); }
+
+.link {
+    color: var(--accent);
+    font-weight: 600;
+    transition: color 150ms;
+}
+
+.link:hover { color: var(--accent-hot); }
+
+/* ─── Layout ───────────────────────────────────────── */
+
+.row-demo, .col-demo {
+    display: flex;
+    flex-direction: row;
+    gap: var(--gap-md);
+}
+
+.swatch {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    flex-grow: 1;
+    padding: 16px;
+    color: var(--bg);
+    font-size: 12px;
+    font-weight: 600;
+    border-radius: 4px;
+    background-color: var(--accent);
+}
+
+.swatch-2 { background-color: var(--warm); }
+.swatch-3 { background-color: var(--rose); flex-grow: 2; }
+
+.cell {
+    flex-grow: 1;
+    padding: 12px;
+    background-color: var(--surface-2);
+    border: 1px solid var(--border-1);
+    border-radius: 4px;
+    font-size: 12px;
+    color: var(--text-2);
+}
+
+.rounded {
+    padding: 16px;
+    background-color: var(--surface-2);
+    border-radius: 12px;
+    border: 1px solid var(--border-2);
+    color: var(--text-1);
+    font-size: 13px;
+}
+
+.gradient {
+    padding: 20px;
+    border-radius: 8px;
+    color: var(--bg);
+    font-size: 13px;
+    font-weight: 600;
+    background: linear-gradient(90deg, var(--accent), var(--rose));
+}
+
+/* ─── Inputs ───────────────────────────────────────── */
+
+.row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
+    padding: 8px;
+    border-radius: 4px;
+    background-color: var(--surface-1);
+    transition: background-color 150ms;
+}
+
+.row:hover {
+    background-color: var(--surface-2);
+}
+
+.label-text {
+    font-size: 13px;
+    color: var(--text-1);
+}
+
+.input {
+    flex-grow: 1;
+    background-color: var(--surface-2);
+    color: var(--text-1);
+    border: 1px solid var(--border-1);
+    border-radius: 4px;
+    padding-left: 10px;
+    padding-right: 10px;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    font-size: 13px;
+    transition: border 180ms, background-color 180ms;
+}
+
+.input:hover { background-color: var(--surface-1); border: 1px solid var(--border-2); }
+.input:focus { background-color: var(--surface-1); border: 1px solid var(--accent); }
+
+.check { width: 18px; height: 18px; }
+
+.check:focus {
+    border: 1px solid var(--accent);
+    border-radius: 3px;
+}
+
+.check:checked {
+    background-color: var(--accent);
+    border: 1px solid var(--accent-hot);
+    border-radius: 3px;
+}
+
+.radio-group {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.btn-secondary, .btn-primary {
+    padding-left: 16px;
+    padding-right: 16px;
+    padding-top: 9px;
+    padding-bottom: 9px;
+    border-radius: 4px;
+    font-size: 13px;
+    font-weight: 600;
+    transition: background-color 180ms, color 180ms, border 180ms, transform 180ms;
+}
+
+.btn-secondary {
+    background-color: var(--surface-2);
+    color: var(--text-1);
+    border: 1px solid var(--border-2);
+}
+
+.btn-secondary:hover {
+    background-color: var(--surface-1);
+    border: 1px solid var(--accent);
+}
+
+.btn-primary {
+    background-color: var(--accent);
+    color: var(--bg);
+    border: 1px solid var(--accent);
+}
+
+.btn-primary:hover {
+    background-color: var(--accent-hot);
+    border: 1px solid var(--accent-hot);
+    transform: scale(1.03);
+}
+
+/* ─── Lists ────────────────────────────────────────── */
+
+.list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.list li {
+    padding-left: 8px;
+    padding-right: 8px;
+    padding-top: 6px;
+    padding-bottom: 6px;
+    border-radius: 3px;
+    background-color: var(--surface-1);
+    color: var(--text-1);
+    font-size: 13px;
+    transition: background-color 150ms;
+}
+
+.list li:hover {
+    background-color: var(--surface-2);
+}
+
+.list li:first-child {
+    color: var(--accent);
+    font-weight: 600;
+}
+
+/* ─── States grid ─────────────────────────────────── */
+
+.state-grid {
+    display: flex;
+    flex-direction: row;
+    gap: var(--gap-md);
+}
+
+.state-card {
+    flex-grow: 1;
+    padding: 20px;
+    background-color: var(--surface-2);
+    border: 1px solid var(--border-1);
+    border-radius: 6px;
+    font-size: 12px;
+    color: var(--text-2);
+    text-align: center;
+    transition: border 180ms, transform 180ms, color 180ms;
+}
+
+.state-card:hover {
+    border: 1px solid var(--accent);
+    color: var(--text-1);
+    transform: scale(1.04);
+}
+
+.focus-demo {
+    background-color: var(--surface-2);
+    color: var(--text-2);
+}
+
+.focus-demo:focus {
+    border: 1px solid var(--accent-hot);
+    color: var(--accent-hot);
+}
+
+.combined:hover:focus {
+    border: 1px solid var(--warm);
+    color: var(--warm);
+}
+
+/* ─── CSS authoring feature list ───────────────────── */
+
+.feat-note {
+    font-size: 13px;
+    color: var(--text-2);
+}
+
+.feat-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.feat-list li {
+    padding-top: 4px;
+    padding-bottom: 4px;
+    font-size: 13px;
+    color: var(--text-1);
+}
+
+code {
+    font-weight: 600;
+    color: var(--accent);
+}

--- a/addons/gtml/plugin.cfg
+++ b/addons/gtml/plugin.cfg
@@ -3,5 +3,5 @@
 name="GTML - Godot Text Markup Language"
 description="GmlView node that builds Godot UI from HTML/CSS files"
 author="Digitzone"
-version="0.4.0"
+version="0.5.0"
 script="plugin.gd"

--- a/addons/gtml/src/css/GmlCssParser.gd
+++ b/addons/gtml/src/css/GmlCssParser.gd
@@ -273,13 +273,17 @@ func _parse_properties() -> Dictionary:
 	return properties
 
 
-## Parse a property name.
+## Parse a property name. Allows identifiers, hyphens, underscores, AND digits
+## for embedded numeric tokens (e.g. ``--surface-2``, ``border-top-width``).
+## CSS forbids leading digits on custom properties, but `--` always prefixes
+## a custom property so the digit can only appear at index >= 2; standard
+## property names start with a letter via the lexer's outer loop.
 func _parse_property_name() -> String:
 	var start := _pos
 
 	while _pos < _length:
 		var ch := _peek()
-		if ch.is_valid_identifier() or ch == "-":
+		if ch.is_valid_identifier() or ch == "-" or ch == "_" or ch.is_valid_int():
 			_advance()
 		else:
 			break

--- a/addons/gtml/src/html_renderer/GmlTransitionManager.gd
+++ b/addons/gtml/src/html_renderer/GmlTransitionManager.gd
@@ -192,27 +192,26 @@ func _animate_height(control: Control, from_value, to_value, tween: Tween, durat
 ## tween. Missing values on either side default to the identity transform
 ## (scale = 1, rotation = 0, translate = ZERO) so going from a transformed
 ## :hover back to a transform-less base reverts cleanly.
-func _animate_transform(control: Control, from_value, to_value, tween: Tween, duration: float) -> void:
-	var from_t := _normalize_transform(from_value)
+##
+## Interruption-safe: we read the live control.scale / control.rotation /
+## control.position rather than the caller's from_value so a hover-in
+## followed by a quick hover-out continues from the mid-tween visual state
+## instead of snapping back to the un-tweened baseline.
+##
+## Base-position fallback: if GmlDimensions hasn't stamped
+## _transform_base_position (the base style had no transform declaration),
+## we stamp it here using the live position so reverts return to layout.
+func _animate_transform(control: Control, _from_value, to_value, tween: Tween, duration: float) -> void:
 	var to_t := _normalize_transform(to_value)
 
-	# Seed the control with the from state so the first frame is correct
-	# even when the caller's previous state didn't match the visual state.
-	control.scale = from_t["scale"]
-	control.rotation = from_t["rotate"]
+	if not control.has_meta("_transform_base_position"):
+		control.set_meta("_transform_base_position", control.position)
+	var base_pos: Vector2 = control.get_meta("_transform_base_position")
 
 	tween.set_parallel(true)
 	tween.tween_property(control, "scale", to_t["scale"], duration)
 	tween.tween_property(control, "rotation", to_t["rotate"], duration)
-
-	# Translate animates the position relative to the layout-driven base.
-	# GmlDimensions stamps _transform_base_position on first build; we fall
-	# back to the control's current position when that meta is absent.
-	var base_pos: Vector2 = control.get_meta("_transform_base_position", control.position)
-	var to_pos: Vector2 = base_pos + to_t["translate"]
-	var from_pos: Vector2 = base_pos + from_t["translate"]
-	control.position = from_pos
-	tween.tween_property(control, "position", to_pos, duration)
+	tween.tween_property(control, "position", base_pos + to_t["translate"], duration)
 
 
 ## Normalize a transform value to the canonical {translate, scale, rotate}
@@ -373,7 +372,12 @@ func _apply_property_value(control: Control, property: String, value) -> void:
 			var t := _normalize_transform(value)
 			control.scale = t["scale"]
 			control.rotation = t["rotate"]
-			var base_pos: Vector2 = control.get_meta("_transform_base_position", control.position)
+			# Stamp the base position the first time we touch transform so
+			# subsequent reverts return to the pre-translate layout spot
+			# instead of accumulating offsets each toggle.
+			if not control.has_meta("_transform_base_position"):
+				control.set_meta("_transform_base_position", control.position)
+			var base_pos: Vector2 = control.get_meta("_transform_base_position")
 			control.position = base_pos + t["translate"]
 
 

--- a/addons/gtml/src/html_renderer/GmlTransitionManager.gd
+++ b/addons/gtml/src/html_renderer/GmlTransitionManager.gd
@@ -26,12 +26,19 @@ func transition_style(control: Control, from_style: Dictionary, to_style: Dictio
 		if property.is_empty():
 			continue
 
-		# Check if the target style has this property
-		if not to_style.has(property):
+		# Check if the target style has this property. The "transform" composite
+		# is special: if the target style omits it, the implicit value is the
+		# identity transform, so the animation should still fire to revert
+		# scale/rotation/position back to neutral.
+		var to_value
+		if to_style.has(property):
+			to_value = to_style[property]
+		elif property == "transform":
+			to_value = {"translate": Vector2.ZERO, "scale": Vector2.ONE, "rotate": 0.0}
+		else:
 			continue
 
 		var from_value = _get_current_value(control, property, from_style)
-		var to_value = to_style[property]
 
 		# Skip if values are the same
 		if _values_equal(from_value, to_value):
@@ -88,6 +95,8 @@ func _animate_property(control: Control, property: String, from_value, to_value,
 			_animate_width(control, from_value, to_value, tween, duration)
 		"height":
 			_animate_height(control, from_value, to_value, tween, duration)
+		"transform":
+			_animate_transform(control, from_value, to_value, tween, duration)
 		_:
 			# Unknown property - try generic approach
 			_animate_generic(control, property, from_value, to_value, tween, duration)
@@ -176,6 +185,48 @@ func _animate_height(control: Control, from_value, to_value, tween: Tween, durat
 	tween.tween_property(control, "custom_minimum_size:y", float(to_height), duration)
 
 	_track_value_during_tween(control, "height", from_height, to_height, tween, duration)
+
+
+## Animate the transform composite — scale (Vector2), rotation (float),
+## and translate offset (Vector2) interpolate in parallel through the same
+## tween. Missing values on either side default to the identity transform
+## (scale = 1, rotation = 0, translate = ZERO) so going from a transformed
+## :hover back to a transform-less base reverts cleanly.
+func _animate_transform(control: Control, from_value, to_value, tween: Tween, duration: float) -> void:
+	var from_t := _normalize_transform(from_value)
+	var to_t := _normalize_transform(to_value)
+
+	# Seed the control with the from state so the first frame is correct
+	# even when the caller's previous state didn't match the visual state.
+	control.scale = from_t["scale"]
+	control.rotation = from_t["rotate"]
+
+	tween.set_parallel(true)
+	tween.tween_property(control, "scale", to_t["scale"], duration)
+	tween.tween_property(control, "rotation", to_t["rotate"], duration)
+
+	# Translate animates the position relative to the layout-driven base.
+	# GmlDimensions stamps _transform_base_position on first build; we fall
+	# back to the control's current position when that meta is absent.
+	var base_pos: Vector2 = control.get_meta("_transform_base_position", control.position)
+	var to_pos: Vector2 = base_pos + to_t["translate"]
+	var from_pos: Vector2 = base_pos + from_t["translate"]
+	control.position = from_pos
+	tween.tween_property(control, "position", to_pos, duration)
+
+
+## Normalize a transform value to the canonical {translate, scale, rotate}
+## Dictionary. Accepts a Dictionary (the GmlTransformValues output), an
+## untyped Variant (treated as identity), or null.
+static func _normalize_transform(v) -> Dictionary:
+	if not (v is Dictionary):
+		return {"translate": Vector2.ZERO, "scale": Vector2.ONE, "rotate": 0.0}
+	var d: Dictionary = v
+	return {
+		"translate": d.get("translate", Vector2.ZERO),
+		"scale": d.get("scale", Vector2.ONE),
+		"rotate": d.get("rotate", 0.0),
+	}
 
 
 ## Generic animation for unsupported properties - applies immediately.
@@ -318,6 +369,12 @@ func _apply_property_value(control: Control, property: String, value) -> void:
 			control.custom_minimum_size.x = _to_int(value, 0)
 		"height":
 			control.custom_minimum_size.y = _to_int(value, 0)
+		"transform":
+			var t := _normalize_transform(value)
+			control.scale = t["scale"]
+			control.rotation = t["rotate"]
+			var base_pos: Vector2 = control.get_meta("_transform_base_position", control.position)
+			control.position = base_pos + t["translate"]
 
 
 ## Cancel an existing tween for a property.

--- a/docs/css-selectors.md
+++ b/docs/css-selectors.md
@@ -312,19 +312,104 @@ button:disabled {
 }
 ```
 
+## Combinators
+
+> **Added in v0.2 (descendant, child) / v0.3 (sibling).**
+
+| Combinator | Example | Matches |
+|---|---|---|
+| ` ` (descendant) | `.card p` | `<p>` anywhere inside `.card` |
+| `>` (child) | `.card > p` | `<p>` whose direct parent is `.card` |
+| `+` (adjacent sibling) | `.a + .b` | `.b` immediately preceded by `.a` |
+| `~` (general sibling) | `.a ~ .b` | any `.b` after a `.a` sibling |
+
+Whitespace alone is the descendant combinator. `.a+.b` (no spaces) is
+equivalent to `.a + .b`.
+
+## Compound selectors
+
+Multiple simple selectors stacked with no combinator target the same
+element. All constraints must match.
+
+```css
+div.card           /* div with class "card" */
+button.primary     /* button with class "primary" */
+input#email        /* input with id "email" */
+div.card.featured  /* div with both classes */
+```
+
+## Attribute selectors
+
+> **Added in v0.2 (`[attr]`, `[attr="val"]`) / v0.3 (substring matchers).**
+
+| Form | Matches |
+|---|---|
+| `[attr]` | element has the attribute (any value) |
+| `[attr="value"]` | exact match (quotes optional) |
+| `[attr~="word"]` | whitespace-separated word list contains "word" as a whole word |
+| `[attr^="prefix"]` | value starts with "prefix" |
+| `[attr$="suffix"]` | value ends with "suffix" |
+| `[attr*="substr"]` | value contains "substr" anywhere |
+
+```css
+input[disabled] { opacity: 0.5; }
+input[type="email"] { font-family: 'monospace'; }
+a[href^="https://"] { color: blue; }
+img[src$=".svg"] { background-color: white; }
+[class~="card"] { padding: 16px; }
+```
+
+## Structural pseudo-classes
+
+> **Added in v0.3.**
+
+| Pseudo | Matches |
+|---|---|
+| `:first-child` | first element child of its parent |
+| `:last-child` | last element child |
+| `:only-child` | the sole element child |
+| `:nth-child(N)` | the Nth element child (1-based) |
+| `:nth-child(odd \| even)` | by parity |
+| `:nth-child(an+b)` | matches positions a·n + b for n ≥ 0 |
+| `:not(selector)` | negation; argument is a simple selector |
+
+```css
+.list li:first-child { color: var(--accent); }
+.row:nth-child(2n+1) { background-color: var(--surface-2); }
+p:not(.muted) { color: var(--text-1); }
+```
+
+State pseudos (`:hover`, `:focus`, `:active`, `:disabled`, `:checked`)
+contribute to specificity but do NOT affect DOM matching — see the
+state-pseudo section above.
+
+## Multi-pseudo combined states
+
+> **Added in v0.3.**
+
+```css
+button:hover:focus {
+    background-color: var(--accent-hot);
+}
+```
+
+The rule applies only when ALL listed state pseudos are simultaneously
+active. Combined-state buckets are keyed by the sorted pseudo set, so
+`button:hover:focus` and `button:focus:hover` resolve into the same
+bucket and never duplicate.
+
 ## Limitations
 
 GTML does **not** support:
 
-- Descendant selectors: `div p { }` or `ul li { }`
-- Child selectors: `div > p { }`
-- Sibling selectors: `h1 + p { }` or `h1 ~ p { }`
-- Attribute selectors: `[type="text"] { }`
 - Pseudo-elements: `::before`, `::after`
-- `:nth-child()`, `:first-child`, `:last-child`
-- `:not()` selector
+- `:nth-of-type()`, `:first-of-type`, `:last-of-type`
+- `:nth-last-child()`
+- `:is()`, `:where()`, `:has()`, `:matches()`
+- Namespaced selectors (`ns|tag`)
 
-For complex styling needs, use unique classes or IDs on target elements.
+For substring matchers, multi-segment combinators, and structural pseudos,
+see the sections above — those ARE supported.
 
 ## See Also
 

--- a/docs/css-tokens.md
+++ b/docs/css-tokens.md
@@ -1,0 +1,115 @@
+# CSS Tokens — custom properties, `var()`, `calc()`
+
+GTML supports CSS custom properties as design tokens, with cascading
+inheritance just like the browser engine. They compose with `calc()` for
+derived dimensions.
+
+> **Added in v0.4.** Implementation lives in
+> `addons/gtml/src/css/GmlCssEval.gd`.
+
+## Custom property declarations
+
+Any selector can declare a custom property with the `--` prefix:
+
+```css
+.app {
+    --brand: #5fc8ff;
+    --gap-md: 16px;
+    --gap-lg: 32px;
+}
+```
+
+The declaration is stored as a raw string. Children of the matched element
+inherit the value through the cascade, just like the browser.
+
+There is no special `:root` selector in GTML — the topmost element of your
+HTML doubles as `:root`. Most samples put their palette on the outer
+`.app` / `.page` selector.
+
+## Reading a property with `var()`
+
+```css
+.button {
+    background-color: var(--brand);
+    padding: var(--gap-md);
+}
+```
+
+`var()` resolution happens at compute-style time. The resolver walks the
+DOM and threads a `scope` dict through each node; the scope is the
+ancestor cascade plus the node's own declarations.
+
+### Fallback
+
+`var(--name, fallback)` uses the fallback when the variable isn't in scope:
+
+```css
+.button {
+    color: var(--brand-text, white);
+}
+```
+
+The fallback can itself contain `var()` — resolution recurses.
+
+### Cycle detection
+
+If a variable references itself (directly or via a chain
+`--a → --b → --a`), the resolver breaks the cycle, emits a `push_warning`,
+and treats the value as initial (empty string). The CSS spec's
+"invalid → initial" semantic.
+
+## `calc()` arithmetic
+
+`calc()` evaluates a flat arithmetic expression with `+`, `-`, `*`, `/`
+and standard precedence:
+
+```css
+.sidebar {
+    width: calc(100px + 16px * 2);   /* -> 132px */
+    height: calc(var(--row) * 4);    /* uses scope */
+}
+```
+
+### Unit rules
+
+| Operator | Rule |
+|---|---|
+| `+`, `-` | Both operands must share the same unit (or both be unitless) |
+| `*`, `/` | At most one operand may carry a unit |
+
+Mixing units in an addition (like `calc(100% - 16px)` in current GTML)
+emits a `push_warning` and leaves the substring as-is. Pure arithmetic
+on unitless numbers and same-unit additions both work cleanly.
+
+### Composition with `var()`
+
+`var()` resolution runs before `calc()`, so this:
+
+```css
+.app { --base: 16; }
+.row { padding: calc(var(--base) * 2); }   /* -> 32 */
+```
+
+…evaluates as `calc(16 * 2)` after substitution and yields `32`.
+
+## Bucket-local declarations (limitation)
+
+Custom properties declared inside a state bucket are NOT yet added to that
+bucket's scope:
+
+```css
+p:hover { --x: red; color: var(--x); }   /* -> :hover bucket gets no --x */
+```
+
+The bucket's `var(--x)` resolves against the base scope. Workaround: put
+the `--x` on a non-hover selector that the same element matches.
+
+## Why use them
+
+- Single source of truth for palettes — re-brand by editing one block
+- Derived values stay in sync (`calc(var(--gap-md) * 2)` updates with
+  `--gap-md`)
+- Document intent through naming (`--accent` reads better than `#5fc8ff`)
+
+See `addons/gtml/examples/showcase/atlas/style.css` for a real palette
+that uses the pattern throughout.

--- a/docs/forms-and-inputs.md
+++ b/docs/forms-and-inputs.md
@@ -215,27 +215,100 @@ func _on_selection_changed(select_id: String, value: String):
 
 ### Form Submission
 
-Connect to the `form_submitted` signal:
+> **v0.4: form value collection.**
+
+Submit buttons (`<input type="submit">`) now collect all input values
+automatically and emit them via `form_submitted`:
 
 ```gdscript
 func _ready():
     $GmlView.form_submitted.connect(_on_form_submitted)
 
 func _on_form_submitted(form_data: Dictionary):
-    print("Form data: ", form_data)
-    # form_data contains all input values by ID
+    print(form_data.get("username"))
+    print(form_data.get("remember"))   # true / false from a checkbox
 ```
 
+The dict is populated by `GmlView.get_form_data()` which you can also call
+directly any time you want a snapshot of the current form state. Returned
+types per input:
+
+| Input | Type |
+|---|---|
+| text / password / email / number | `String` |
+| `<textarea>` | `String` |
+| `<input type="range">` | `float` |
+| `<select>` | `String` (item text) |
+| `<input type="checkbox">` (no `name`) | `bool`, keyed by id |
+| `<input type="radio" name="x">` | the SELECTED radio's `value` attr, keyed by `x` |
+
+Radios without a `name` attribute fall back to checkbox semantics —
+always set `name=` on radio groups.
+
+There is no `<form>` scoping in GTML. A bare `<input type="submit">`
+anywhere in a view fires `form_submitted` with the entire view's input
+snapshot. Don't put multiple unrelated forms in one `GmlView`.
+
+### Keyboard events
+
+> **v0.4: `@keydown` attribute.**
+
+Text inputs can declare `@keydown="handler"`. Key-down events fire
+`GmlView.key_pressed(handler, event)`:
+
+```html
+<input id="search" type="text" @keydown="on_search_key">
+```
+
+```gdscript
+func _ready():
+    $GmlView.key_pressed.connect(_on_key)
+
+func _on_key(handler: String, event: InputEvent):
+    if handler == "on_search_key" and event.keycode == KEY_ENTER:
+        run_search($GmlView.get_element_by_id("search").text)
+```
+
+Only `pressed` events fire (key-up is filtered out). The handler value
+is whatever string you put in the attribute; multiple inputs can share
+a handler name and dispatch by id.
+
 ## Label Association
+
+> **v0.3: `<label for>` activation. v0.5: whole-row click target.**
 
 Use the `for` attribute to associate labels with inputs:
 
 ```html
-<label for="username">Username:</label>
-<input type="text" id="username">
+<label for="remember">Remember me</label>
+<input type="checkbox" id="remember">
 ```
 
-Clicking the label will focus the associated input.
+Clicking the label activates the associated input:
+
+- **checkbox**: toggles
+- **radio in a group**: selects (never deselects)
+- **text input / other Control**: grabs focus
+
+### Whole-row click targets
+
+A `<label>` with element children becomes a container — the whole surface
+becomes the click target. This is the standard HTML `<label><input>`
+pattern:
+
+```html
+<label class="row" for="opt-in">
+    <input id="opt-in" type="checkbox">
+    <div>
+        <span class="strong">Email me about updates</span>
+        <span class="muted">Twice a month. Unsubscribe anytime.</span>
+    </div>
+</label>
+```
+
+Now any click on the whole row toggles the checkbox. The inner `<input>`
+still gets its own click events (Godot consumes them before they reach
+the container) so there's no double-toggle.
 
 ## Styling Form Elements
 
@@ -257,14 +330,39 @@ input:focus, textarea:focus, select:focus {
 }
 ```
 
-### Checkbox Styling
+### Checkbox / Radio Styling
+
+> **v0.4: `:checked` pseudo. v0.3: `:focus` stylebox.**
+
+Checkboxes and radios respect three state pseudos at the CSS level:
 
 ```css
-input[type="checkbox"] {
-    /* Checkboxes have limited styling */
-    /* Use background-color for the box */
+.check {
+    width: 18px;
+    height: 18px;
+}
+
+.check:focus {
+    border: 1px solid var(--accent);
+    border-radius: 3px;
+}
+
+.check:checked {
+    background-color: var(--accent);
+    border: 1px solid var(--accent-hot);
+    border-radius: 3px;
 }
 ```
+
+How they map under the hood:
+
+- `:focus` installs a custom `focus` theme stylebox in place of Godot's
+  default focus rectangle. Empty rule (`{}`) installs `StyleBoxEmpty`
+  for explicit opt-out.
+- `:checked` installs a custom `pressed` theme stylebox (Godot uses the
+  `pressed` slot as toggle-on for toggle buttons).
+- The pseudos compose with the rest of the rule's properties —
+  `background-color`, `border`, `border-radius` all flow through.
 
 ### Range Slider Styling
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -202,6 +202,18 @@ Check out the example files in `addons/gtml/examples/`:
 ## Next Steps
 
 - [HTML Elements](html-elements.md) - All supported tags and attributes
+- [CSS Selectors](css-selectors.md) - Combinators, attribute matchers, pseudo-classes
 - [CSS Properties](css-properties.md) - Complete CSS reference
+- [CSS Tokens](css-tokens.md) - Custom properties, `var()`, `calc()`
+- [Transforms](transforms.md) - `translate`, `scale`, `rotate` + animations
 - [Layout & Flexbox](layout-and-flexbox.md) - Layout system guide
-- [Forms & Inputs](forms-and-inputs.md) - Form element details
+- [Transitions](transitions.md) - Animated state changes
+- [Forms & Inputs](forms-and-inputs.md) - Form element details, `:checked`, `@keydown`
+
+### Showcase samples
+
+The `addons/gtml/examples/showcase/` directory has four crafted demos —
+**atlas** (dashboard), **atelier** (editorial reader), **forge**
+(settings panel), and **kitchen** (kitchen-sink reference). Each uses the
+v0.4 design-token + transform patterns and is good starting material for
+your own scenes.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -19,24 +19,27 @@ CSS must be in external files. Inline `<style>` tags and `style` attributes are 
 
 **Workaround:** Use external CSS files and classes.
 
-### No Descendant Selectors
+### Selector engine — supported as of v0.2 / v0.3
 
-Complex selectors like descendant, child, or sibling selectors are not supported.
+Descendant, child, sibling, attribute, and structural selectors are all
+supported now. See [css-selectors.md](css-selectors.md) for the full list.
+Specifically:
 
 ```css
-/* NOT supported */
+/* Supported */
 div p { }           /* Descendant */
 div > p { }         /* Child */
-h1 + p { }          /* Adjacent sibling */
-h1 ~ p { }          /* General sibling */
-ul li a { }         /* Nested descendant */
-
-/* Supported */
-.card-text { }      /* Use classes */
-#specific-item { }  /* Use IDs */
+h1 + p { }          /* Adjacent sibling (v0.3) */
+h1 ~ p { }          /* General sibling (v0.3) */
+[type="text"] { }   /* Attribute (v0.2) */
+[href^="https"] { } /* Attribute prefix matcher (v0.3) */
+li:first-child { }  /* Structural pseudos (v0.3) */
+li:nth-child(2n+1) { } /* an+b syntax (v0.3) */
+p:not(.muted) { }   /* Negation (v0.3) */
 ```
 
-**Workaround:** Use unique class names or IDs on target elements.
+What's still not supported: `::before`, `::after`, `:nth-of-type`,
+`:first-of-type`, `:is()`, `:where()`, `:has()`.
 
 ### No Multi-Value Shorthand
 
@@ -80,24 +83,25 @@ font-size: 24px;
 margin: 20px;
 ```
 
-### No CSS Variables
+### CSS Variables — supported as of v0.4
 
-Custom properties are not supported.
+Custom properties cascade just like the browser engine. `var()` resolves
+at compute-style time with cycle detection; `calc()` evaluates flat
+arithmetic. See [css-tokens.md](css-tokens.md):
 
 ```css
-/* NOT supported */
-:root {
-    --primary-color: #00d4ff;
+.app {
+    --brand: #00d4ff;
+    --gap: 16px;
 }
 button {
-    background-color: var(--primary-color);
-}
-
-/* Supported - use direct values */
-button {
-    background-color: #00d4ff;
+    background-color: var(--brand);
+    padding: calc(var(--gap) * 0.5);
 }
 ```
+
+`calc()` doesn't yet handle mixed-unit subtraction (`calc(100% - 16px)`).
+Same-unit and unitless arithmetic both work.
 
 ### No CSS Animations
 
@@ -139,34 +143,21 @@ The `!important` flag is not supported.
 }
 ```
 
-### No Attribute Selectors
+### Structural pseudos and attribute selectors — supported (v0.3)
+
+See [css-selectors.md](css-selectors.md). Quick recap:
 
 ```css
-/* NOT supported */
-[type="text"] { }
-[disabled] { }
-[data-custom="value"] { }
-
-/* Workaround - use classes */
-.text-input { }
-.disabled { }
-.custom-value { }
+[type="text"] { }              /* attribute equality */
+[href^="https"] { }            /* prefix matcher */
+[class~="card"] { }            /* whitespace-word matcher */
+li:first-child { }             /* first / last / only */
+li:nth-child(2n+1) { }         /* odd/even/an+b */
+p:not(.muted) { }              /* negation */
 ```
 
-### No :nth-child Selectors
-
-```css
-/* NOT supported */
-li:nth-child(odd) { }
-li:first-child { }
-li:last-child { }
-li:nth-of-type(2n) { }
-
-/* Workaround - use classes */
-.odd-item { }
-.first-item { }
-.last-item { }
-```
+What's NOT yet supported: `:nth-of-type`, `:first-of-type`, `:last-of-type`,
+`:nth-last-child`, `:is()`, `:where()`, `:has()`.
 
 ### No Pseudo-Elements
 

--- a/docs/transforms.md
+++ b/docs/transforms.md
@@ -1,0 +1,108 @@
+# Transforms
+
+GTML supports the CSS `transform` property — `translate`, `scale`, and
+`rotate`. Transforms map to `Control.position`, `Control.scale`, and
+`Control.rotation` respectively, with `pivot_offset` set to the element's
+visual centre so scale/rotate behave like the CSS default
+`transform-origin: 50% 50%`.
+
+> **Added in v0.4.** Animated transitions for `transform` added in v0.5.
+> Parser lives in `addons/gtml/src/css/values/GmlTransformValues.gd`;
+> application in `addons/gtml/src/html_renderer/GmlDimensions.gd`.
+
+## Syntax
+
+```css
+.card {
+    transform: translate(10px, 0);
+}
+
+.icon-rotated {
+    transform: rotate(45deg);
+}
+
+.hero-image {
+    transform: scale(1.05);
+}
+```
+
+### Function reference
+
+| Function | Args | Notes |
+|---|---|---|
+| `translate(x[, y])` | px values | second arg defaults to 0 |
+| `translateX(x)` | px | shorthand for `translate(x, 0)` |
+| `translateY(y)` | px | shorthand for `translate(0, y)` |
+| `scale(s)` | unitless | uniform scale on both axes |
+| `scale(sx, sy)` | unitless | per-axis scale |
+| `scaleX(s)` / `scaleY(s)` | unitless | per-axis shorthand |
+| `rotate(45deg)` | angle | accepts `deg`, `rad`, `turn`, or a bare number (treated as degrees) |
+
+### Composition
+
+Multiple functions in one declaration compose left-to-right; later writes
+overwrite earlier ones for the same axis:
+
+```css
+.thing {
+    transform: translate(10px, 0) scale(1.05) rotate(-3deg);
+}
+```
+
+## Animating transforms
+
+Include `transform` in a `transition` declaration and the transition
+manager interpolates scale, rotation, and translate together through a
+single tween:
+
+```css
+.card {
+    transition: transform 220ms;
+}
+
+.card:hover {
+    transform: scale(1.04);
+}
+```
+
+When the target style omits `transform`, the manager treats the implicit
+target as the identity transform `{translate: 0,0; scale: 1,1; rotate: 0}`
+and animates back to neutral — so hover-out reverts cleanly without
+needing an explicit `:not(:hover)` rule.
+
+### Composing with other transitions
+
+`transform` plays nicely with other transitioned properties on the same
+rule:
+
+```css
+.btn-primary {
+    transition: background-color 180ms, transform 180ms;
+}
+
+.btn-primary:hover {
+    background-color: var(--accent-hot);
+    transform: scale(1.03);
+}
+```
+
+## Pivot
+
+`pivot_offset` is recomputed on the control's first frame and on every
+`resized` signal to keep the visual centre as the rotation/scale anchor.
+There is no `transform-origin` property yet — if you need an off-centre
+pivot, anchor your element manually via Container layout.
+
+## Limitations
+
+- Only `translate` / `scale` / `rotate` are supported. `skew`, `matrix`,
+  3D transforms (`translate3d`, `rotateX`/`rotateY`/`rotateZ`,
+  `perspective`) are not implemented.
+- `transform-origin` is not parsed; it defaults to the visual centre.
+- `transform` arguments are split on commas at the function level. Nested
+  CSS values like `translate(calc(10px + 5px), 0)` work because the
+  resolver evaluates `calc()` before transform parsing — but only because
+  the result is a literal by the time the transform parser sees it.
+
+See `addons/gtml/examples/showcase/kitchen/` for a single-scene reference
+exercising every transform function with transitions.

--- a/docs/transitions.md
+++ b/docs/transitions.md
@@ -84,6 +84,50 @@ These properties can be smoothly animated:
 | `opacity` | Fade in/out effects |
 | `width` | Size animations |
 | `height` | Size animations |
+| `transform` | scale / rotate / translate composite (v0.5) |
+
+### Animating `transform`
+
+> **v0.5: transform interpolation through the transition manager.**
+
+`transform` interpolates as a single composite — scale (Vector2), rotation
+(float), and the layout-relative position offset (Vector2) all tween in
+parallel through one tween:
+
+```css
+.card {
+    transition: transform 220ms;
+}
+
+.card:hover {
+    transform: scale(1.04);
+}
+```
+
+When the target style omits `transform`, the manager treats the implicit
+target as the identity transform `{translate: 0,0; scale: 1,1; rotate: 0}`
+and animates back to neutral — so hover-out reverts cleanly without
+needing an explicit `:not(:hover)` rule.
+
+See [transforms.md](transforms.md) for the full transform syntax.
+
+### Heads-up: `transparent → opaque` color flash
+
+The color tween interpolates RGBA, so a transition from
+`background-color: transparent` to an opaque color passes through
+alpha-blended intermediate frames that visually read as a gray "flash".
+
+Use an opaque base color matching the parent surface:
+
+```css
+/* Avoid */
+.nav-item { background-color: transparent; }
+.nav-item:hover { background-color: #1a1a2e; }
+
+/* Prefer */
+.nav-item { background-color: #0c1120; }  /* parent surface */
+.nav-item:hover { background-color: #1a1a2e; }
+```
 
 ## Multiple Transitions
 

--- a/tests/unit/test_css_tokens.gd
+++ b/tests/unit/test_css_tokens.gd
@@ -84,6 +84,16 @@ func test_var_in_dimension_property() -> void:
 	assert_eq(s.get("padding"), 24)
 
 
+func test_custom_property_name_with_digit() -> void:
+	# Pin the lexer change that allowed digits in property names. Without
+	# it, --surface-2 truncated to --surface- and parsing collapsed.
+	var s := _style_for_id(
+		"<div id='target'>x</div>",
+		"div { --surface-2: blue; color: var(--surface-2); }",
+		"target")
+	assert_eq(s.get("color"), Color.BLUE)
+
+
 #endregion
 
 

--- a/tests/unit/test_renderer_smoke.gd
+++ b/tests/unit/test_renderer_smoke.gd
@@ -20,6 +20,7 @@ const SHOWCASES := [
 	{"name": "atlas", "dir": "showcase/atlas"},
 	{"name": "atelier", "dir": "showcase/atelier"},
 	{"name": "forge", "dir": "showcase/forge"},
+	{"name": "kitchen", "dir": "showcase/kitchen"},
 ]
 
 
@@ -87,6 +88,14 @@ func test_showcase_forge_renders() -> void:
 	# opening the Forge demo in the editor.
 	var v := _build_showcase(SHOWCASES[2])
 	await _assert_built(v, "forge")
+
+
+func test_showcase_kitchen_renders() -> void:
+	# Kitchen-sink reference card — exercises virtually every element +
+	# CSS property in one scene, so renderer regressions on any of them
+	# will fail this build.
+	var v := _build_showcase(SHOWCASES[3])
+	await _assert_built(v, "kitchen")
 
 
 func test_get_element_by_id_returns_control() -> void:

--- a/tests/unit/test_transform_transitions.gd
+++ b/tests/unit/test_transform_transitions.gd
@@ -1,0 +1,85 @@
+extends GutTest
+
+## v0.5: transition manager interpolates the transform property —
+## scale (Vector2), rotation (float), and translate offset (Vector2)
+## animate together when transform appears in a transitioned :hover/:focus
+## state bucket.
+
+const GmlTransitionManagerScript = preload("res://addons/gtml/src/html_renderer/GmlTransitionManager.gd")
+
+
+func _control() -> Control:
+	var c := Control.new()
+	c.size = Vector2(100, 50)
+	add_child_autofree(c)
+	return c
+
+
+func _transitions(duration_ms: int = 0) -> Array:
+	return [{
+		"property": "transform",
+		"duration": duration_ms / 1000.0,
+		"timing": {"trans_type": Tween.TRANS_LINEAR, "ease_type": Tween.EASE_IN_OUT},
+		"delay": 0.0,
+	}]
+
+
+func test_transform_scale_applied_via_zero_duration_transition() -> void:
+	# duration: 0 short-circuits to immediate apply — exercises the dispatch
+	# path without waiting for tween frames.
+	var c := _control()
+	var manager = GmlTransitionManagerScript.new()
+	var from := {"transform": {"translate": Vector2.ZERO, "scale": Vector2.ONE, "rotate": 0.0}}
+	var to := {"transform": {"translate": Vector2.ZERO, "scale": Vector2(1.5, 1.5), "rotate": 0.0}}
+	manager.transition_style(c, from, to, _transitions(0))
+	assert_eq(c.scale, Vector2(1.5, 1.5))
+
+
+func test_transform_rotate_applied_via_zero_duration_transition() -> void:
+	var c := _control()
+	var manager = GmlTransitionManagerScript.new()
+	var from := {"transform": {"translate": Vector2.ZERO, "scale": Vector2.ONE, "rotate": 0.0}}
+	var to := {"transform": {"translate": Vector2.ZERO, "scale": Vector2.ONE, "rotate": PI / 4.0}}
+	manager.transition_style(c, from, to, _transitions(0))
+	assert_almost_eq(c.rotation, PI / 4.0, 0.001)
+
+
+func test_transform_reverts_to_base_when_target_has_no_transform() -> void:
+	# Going from a scaled state back to a style with no transform should
+	# reset to identity (scale=1, rotation=0, no translate offset).
+	var c := _control()
+	c.scale = Vector2(1.5, 1.5)
+	c.rotation = 0.3
+	var manager = GmlTransitionManagerScript.new()
+	var from := {"transform": {"translate": Vector2.ZERO, "scale": Vector2(1.5, 1.5), "rotate": 0.3}}
+	var to := {}  # no transform key in target
+	manager.transition_style(c, from, to, _transitions(0))
+	assert_eq(c.scale, Vector2.ONE, "scale should revert to 1 when target has no transform")
+	assert_almost_eq(c.rotation, 0.0, 0.001)
+
+
+func test_transform_with_duration_eventually_reaches_target_value() -> void:
+	# Real tween path — kick off a short animation, wait it out, verify the
+	# final value matches the target. Catches setup-but-no-tween bugs.
+	var c := _control()
+	var manager = GmlTransitionManagerScript.new()
+	var from := {"transform": {"translate": Vector2.ZERO, "scale": Vector2.ONE, "rotate": 0.0}}
+	var to := {"transform": {"translate": Vector2.ZERO, "scale": Vector2(1.2, 1.2), "rotate": 0.0}}
+	manager.transition_style(c, from, to, _transitions(50))
+	# Wait long enough for the 50ms tween to finish.
+	await get_tree().create_timer(0.15).timeout
+	assert_eq(c.scale, Vector2(1.2, 1.2))
+
+
+func test_transform_intermediate_frame_is_between_endpoints() -> void:
+	# Mid-animation, scale must be strictly between from and to. Confirms
+	# the tween is actually interpolating, not snapping at frame 0 or N.
+	var c := _control()
+	var manager = GmlTransitionManagerScript.new()
+	var from := {"transform": {"translate": Vector2.ZERO, "scale": Vector2.ONE, "rotate": 0.0}}
+	var to := {"transform": {"translate": Vector2.ZERO, "scale": Vector2(2.0, 2.0), "rotate": 0.0}}
+	manager.transition_style(c, from, to, _transitions(200))
+	await get_tree().create_timer(0.08).timeout
+	# Roughly 40% through: scale.x should be ~1.4, definitely between 1 and 2.
+	assert_true(c.scale.x > 1.05 and c.scale.x < 1.95,
+		"mid-tween scale.x should be strictly between 1 and 2, got %s" % c.scale.x)

--- a/tests/unit/test_transform_transitions.gd
+++ b/tests/unit/test_transform_transitions.gd
@@ -83,3 +83,101 @@ func test_transform_intermediate_frame_is_between_endpoints() -> void:
 	# Roughly 40% through: scale.x should be ~1.4, definitely between 1 and 2.
 	assert_true(c.scale.x > 1.05 and c.scale.x < 1.95,
 		"mid-tween scale.x should be strictly between 1 and 2, got %s" % c.scale.x)
+
+
+#region Review fixups
+
+
+func test_transform_combined_with_color_both_fire() -> void:
+	# A single transition list with two animated properties should drive
+	# both — verifies the dispatch loop isn't short-circuiting after the
+	# transform branch.
+	var c := _control()
+	var manager = GmlTransitionManagerScript.new()
+	var from := {
+		"transform": {"translate": Vector2.ZERO, "scale": Vector2.ONE, "rotate": 0.0},
+		"opacity": 1.0,
+	}
+	var to := {
+		"transform": {"translate": Vector2.ZERO, "scale": Vector2(1.4, 1.4), "rotate": 0.0},
+		"opacity": 0.5,
+	}
+	var transitions := [
+		{"property": "transform", "duration": 0.0, "timing": {}, "delay": 0.0},
+		{"property": "opacity", "duration": 0.0, "timing": {}, "delay": 0.0},
+	]
+	manager.transition_style(c, from, to, transitions)
+	assert_eq(c.scale, Vector2(1.4, 1.4))
+	assert_almost_eq(c.modulate.a, 0.5, 0.001)
+
+
+func test_transform_interruption_continues_from_live_value() -> void:
+	# Start a 200ms tween; halfway through, request a new transition with
+	# a different target. The new tween must pick up from the LIVE scale,
+	# not snap back to the original from_value.
+	var c := _control()
+	var manager = GmlTransitionManagerScript.new()
+	var from := {"transform": {"translate": Vector2.ZERO, "scale": Vector2.ONE, "rotate": 0.0}}
+	var to_big := {"transform": {"translate": Vector2.ZERO, "scale": Vector2(2.0, 2.0), "rotate": 0.0}}
+	manager.transition_style(c, from, to_big, _transitions(200))
+	await get_tree().create_timer(0.08).timeout
+	var mid := c.scale.x
+	assert_true(mid > 1.05 and mid < 1.95, "setup: mid-tween value should be between, got %s" % mid)
+
+	# Now reverse course; the snap-prevention fix should leave the next
+	# frame near the live mid value, not at 2 (where the from for the
+	# reverse animation was) or 1 (the original baseline).
+	var to_small := {"transform": {"translate": Vector2.ZERO, "scale": Vector2.ONE, "rotate": 0.0}}
+	manager.transition_style(c, to_big, to_small, _transitions(200))
+	await get_tree().process_frame
+	# After one frame the new tween hasn't moved much — scale.x should be
+	# within a hair of the live mid value, not snapped to 2.
+	assert_true(abs(c.scale.x - mid) < 0.5,
+		"second tween should continue from live %s, got %s (snapped?)" % [mid, c.scale.x])
+
+
+func test_transform_translate_reverts_when_base_lacks_transform_meta() -> void:
+	# Atelier .side-item-link case: base style has NO transform, so
+	# GmlDimensions never stamps _transform_base_position. The transition
+	# manager should stamp it lazily on first hover so the revert returns
+	# to the original layout position.
+	var c := Control.new()
+	c.position = Vector2(40, 80)
+	add_child_autofree(c)
+	var manager = GmlTransitionManagerScript.new()
+
+	# Hover-in: translate by +2px
+	var from := {}  # no transform
+	var to := {"transform": {"translate": Vector2(2, 0), "scale": Vector2.ONE, "rotate": 0.0}}
+	manager.transition_style(c, from, to, _transitions(0))
+	assert_eq(c.position, Vector2(42, 80), "hover-in should translate +2 from layout position")
+
+	# Hover-out: target style omits transform — should revert to (40, 80)
+	manager.transition_style(c, to, {}, _transitions(0))
+	assert_eq(c.position, Vector2(40, 80), "hover-out should revert to layout position")
+
+
+func test_transform_delay_is_honored() -> void:
+	# Start a tween with a 60ms delay + 100ms duration. At t=20ms (still
+	# in delay), scale should be unchanged. At t=200ms (after full run),
+	# it should be at the target.
+	var c := _control()
+	var manager = GmlTransitionManagerScript.new()
+	var from := {"transform": {"translate": Vector2.ZERO, "scale": Vector2.ONE, "rotate": 0.0}}
+	var to := {"transform": {"translate": Vector2.ZERO, "scale": Vector2(1.5, 1.5), "rotate": 0.0}}
+	var transitions := [{
+		"property": "transform",
+		"duration": 0.1,
+		"timing": {"trans_type": Tween.TRANS_LINEAR, "ease_type": Tween.EASE_IN_OUT},
+		"delay": 0.06,
+	}]
+	manager.transition_style(c, from, to, transitions)
+	await get_tree().create_timer(0.02).timeout
+	# Mid-delay: scale should still be 1 (delay not yet expired).
+	# Some Tween impls might start slightly early; allow a small tolerance.
+	assert_true(c.scale.x < 1.1, "delay window should keep scale near 1, got %s" % c.scale.x)
+	await get_tree().create_timer(0.25).timeout
+	assert_eq(c.scale, Vector2(1.5, 1.5), "post-delay+duration: should reach target")
+
+
+#endregion


### PR DESCRIPTION
## Summary

Animated transforms, sample polish with v0.4 features, a kitchen-sink reference scene, and a full docs sweep. 7 commits, **162/162 tests green**.

## Highlights

| | |
|---|---|
| **transform transitions** | `transform: scale/rotate/translate` now interpolates through `transition` declarations. Hover-out automatically reverts to identity when the base style omits transform. Interruption-safe — mid-tween hover toggles continue from the live value instead of snapping. |
| **Kitchen-sink showcase** | New 4th sample at `addons/gtml/examples/showcase/kitchen/` — every supported element + CSS property in one scene. Doubles as a regression smoke test. |
| **Polished atlas / atelier / forge** | All three palettes extracted to `--*` custom properties; hover transforms on KPI cards + primary buttons; Atelier link gets a 2px translate; Forge checkboxes/radios fill with the accent on `:checked`. |
| **Property names accept digits** | `--surface-2` no longer truncates to `--surface-` at parse time. |
| **Docs refresh** | Two new pages (`css-tokens.md`, `transforms.md`) + targeted updates to selectors / forms / transitions / getting-started / limitations. |

## Stats

| | |
|---|---|
| Tests | 162 (was 158) |
| Plugin version | 0.4.0 → 0.5.0 |
| Showcase samples | 3 → 4 |
| Doc pages | 11 → 13 |

## Test plan

- [ ] `godot --headless -s addons/gut/gut_cmdln.gd -gconfig=res://.gutconfig.json` → 162/162
- [ ] Open `addons/gtml/examples/showcase/atlas/demo.tscn`; hover a KPI card and "Trigger sweep" → smooth scale + color tween. Hover-out reverses cleanly with no snap.
- [ ] Open Forge; click a checkbox row → fills with violet. Tab to focus → violet outline. Hover the Save button → scales up slightly.
- [ ] Open Atelier; hover a "Related" item → 2px translate + rust color shift. Move mouse away → animates back to the layout position.
- [ ] Open the new `addons/gtml/examples/showcase/kitchen/demo.tscn` → renders every section. Hover the `:hover scales 1.04` state card. Tab to the `:focus` button. Test the radio group.

## Notes / limitations

- `transform-origin` is not parsed; pivot defaults to the visual centre.
- 3D transforms (`translate3d`, `perspective`, `rotateX/Y/Z`), `skew`, and `matrix` are not supported.
- `calc()` still doesn't handle mixed-unit subtraction (`calc(100% - 16px)`).